### PR TITLE
Firefoxでログイン画面の「@」ラベルが潰れる問題を修正

### DIFF
--- a/app/features/login/login-form.tsx
+++ b/app/features/login/login-form.tsx
@@ -43,7 +43,7 @@ export function LoginForm() {
         )}
         <div className="form-control">
           <div className="join">
-            <div className="join-item flex h-full w-12 items-center justify-center rounded-r-full bg-neutral text-neutral-content">
+            <div className="join-item flex w-12 items-center justify-center rounded-r-full bg-neutral text-neutral-content">
               <AtSymbolIcon className="size-5" />
             </div>
             <input


### PR DESCRIPTION
こんにちは。Firefoxでログインページを確認したところ、「@」の部分がスタイルが崩れているのに気づきました。

Tailwindの`h-full`が`height: 100%`を設定していますが、どうやらFirefoxとChromium系ブラウザでは親要素に高さが設定されていないときの高さの計算が異なるのが原因みたいです。

### Before
![Screenshot from 2025-01-20 02-30-25](https://github.com/user-attachments/assets/6a08564d-9275-4598-9e13-1e1ae9d96475)

### After
![Screenshot from 2025-01-20 02-30-47](https://github.com/user-attachments/assets/a25891cc-c517-41fa-8e36-c500385b4d77)
