### PR TITLE
ログインフォームのハンドル検証を@atproto/syntaxのensureValidHandleに変更

### DIFF
--- a/app/features/login/login-form.tsx
+++ b/app/features/login/login-form.tsx
@@ -1,3 +1,4 @@
+import { ensureValidHandle } from "@atproto/syntax";
 import { getFormProps, getInputProps, useForm } from "@conform-to/react";
 import { getZodConstraint, parseWithZod } from "@conform-to/zod";
 import { AtSymbolIcon } from "@heroicons/react/24/outline";
@@ -8,6 +9,15 @@ import { z } from "zod";
 import { Button } from "~/components/button";
 import { Card } from "~/components/card";
 
+const isValidHandle = (value: string) => {
+  try {
+    ensureValidHandle(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export function LoginForm() {
   const { t } = useTranslation();
   const navigation = useNavigation();
@@ -15,7 +25,7 @@ export function LoginForm() {
   const schema = z.object({
     identifier: z
       .string({ required_error: t("login-form.required-error-message") })
-      .refine((value) => value.includes(".") && !value.includes("@"), {
+      .refine(isValidHandle, {
         message: t("login-form.invalid-handle-error-message"),
       }),
   });

--- a/app/features/login/login-form.tsx
+++ b/app/features/login/login-form.tsx
@@ -66,7 +66,9 @@ export function LoginForm() {
           </div>
         </div>
         {fields.identifier.errors && (
-          <p className="p-1 text-sm text-error">{fields.identifier.errors}</p>
+          <p className="whitespace-pre-line p-1 text-sm text-error">
+            {fields.identifier.errors}
+          </p>
         )}
         <Button
           type="submit"

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -15,7 +15,7 @@
   },
   "login-form": {
     "required-error-message": "Please enter a value",
-    "invalid-handle-error-message": "Please enter a valid domain format (e.g., example.bsky.social)",
+    "invalid-handle-error-message": "Please enter a valid handle format\n(e.g., example.bsky.social)",
     "login-title": "Login with ATProto",
     "login-description": "Please enter your Bluesky or Self-hosting PDS account handle.",
     "login-button": "Login (redirects to an authorize page)"

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -15,7 +15,7 @@
   },
   "login-form": {
     "required-error-message": "Please enter a value",
-    "invalid-handle-error-message": "Enter in the format example.bsky.social",
+    "invalid-handle-error-message": "Please enter a valid domain format (e.g., example.bsky.social)",
     "login-title": "Login with ATProto",
     "login-description": "Please enter your Bluesky or Self-hosting PDS account handle.",
     "login-button": "Login (redirects to an authorize page)"

--- a/app/i18n/locales/ja.json
+++ b/app/i18n/locales/ja.json
@@ -16,7 +16,7 @@
   },
   "login-form": {
     "required-error-message": "入力してください",
-    "invalid-handle-error-message": "正しいドメイン形式で入力してください（例: example.bsky.social）",
+    "invalid-handle-error-message": "正しいハンドルの形式で入力してください\n（例: example.bsky.social）",
     "login-title": "ATProtoでログイン",
     "login-description": "Bluesky または Self-hosting PDS アカウントのハンドルを入力してください。",
     "login-button": "ログイン (許可ページに移動します)"

--- a/app/i18n/locales/ja.json
+++ b/app/i18n/locales/ja.json
@@ -16,7 +16,7 @@
   },
   "login-form": {
     "required-error-message": "入力してください",
-    "invalid-handle-error-message": "example.bsky.socialのように入力してください",
+    "invalid-handle-error-message": "正しいドメイン形式で入力してください（例: example.bsky.social）",
     "login-title": "ATProtoでログイン",
     "login-description": "Bluesky または Self-hosting PDS アカウントのハンドルを入力してください。",
     "login-button": "ログイン (許可ページに移動します)"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@atproto/lexicon": "0.4.11",
     "@atproto/oauth-client-node": "0.3.1",
     "@atproto/repo": "0.8.3",
+    "@atproto/syntax": "0.4.0",
     "@atproto/xrpc": "0.7.0",
     "@atproto/xrpc-server": "0.8.0",
     "@conform-to/react": "1.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@atproto/repo':
         specifier: 0.8.3
         version: 0.8.3
+      '@atproto/syntax':
+        specifier: 0.4.0
+        version: 0.4.0
       '@atproto/xrpc':
         specifier: 0.7.0
         version: 0.7.0


### PR DESCRIPTION
- カスタムバリデーションをATProto公式のハンドル検証に置き換え
- エラーメッセージをより具体的な表現に更新
- @atproto/syntaxパッケージを依存関係に追加

🤖 Generated with [Claude Code](https://claude.ai/code)