### PR TITLE
copy pnpm-workspace.yaml in Docker build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm i -g corepack@latest && \
     corepack enable pnpm
 
 FROM base AS build
-COPY --link package.json pnpm-lock.yaml .atproto-version ./
+COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml .atproto-version ./
 COPY --link scripts ./scripts
 COPY --link prisma ./prisma
 COPY --link lexicons ./lexicons


### PR DESCRIPTION
## Summary
- Dockerfile の `pnpm install --frozen-lockfile` 実行前に `pnpm-workspace.yaml` をコピーするよう修正

## 背景
PR #274 の preview デプロイがビルド時に `[ERR_PNPM_IGNORED_BUILDS]` で失敗していた。

- Dockerfile の build ステージでは `package.json` と `pnpm-lock.yaml` だけをコピーしてから `pnpm install` を実行していたため、`pnpm-workspace.yaml` の `allowBuilds:` 設定がコンテナ内で読まれていなかった
- production の最新ビルドは Railway の Nixpacks キャッシュにあった pnpm v10.33.4 がたまたま使われ「警告 + exit 0」で通っていた
- 一方 PR 環境は Corepack 経由で pnpm v11.1.1 を取りに行き、v11 では `ERR_PNPM_IGNORED_BUILDS` が exit 1 のハードエラーになるため失敗していた

## Test plan
- [x] mainの `pnpm-workspace.yaml` のままローカルで `rm -rf node_modules && pnpm install --frozen-lockfile` が pnpm v11.1.1 で exit 0 で完了することを確認
- [ ] このPRのpreview環境でビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)