### PR TITLE
package.jsonのenginesを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "type": "module",
   "private": true,
   "packageManager": "pnpm@11.3.0",
-  "engines": {
-    "node": ">=22.0.0"
-  },
   "scripts": {
     "_eslint": "eslint --cache --cache-location ./node_modules/.cache/eslint",
     "all": "run-s typecheck format test",


### PR DESCRIPTION
## Summary
- \`engines\` フィールドを削除
- \`private: true\` のアプリで、Nodeバージョンは \`.node-version\` と Dockerfile (\`FROM node:24.16.0-slim\`) で固定済みのため不要

## Test plan
- [ ] CI (unit-test, e2e-test) が通ること