### PR TITLE
ダークモードでアイコンとボタン文字が暗色になる問題を修正

### DIFF
--- a/app/components/layout.tsx
+++ b/app/components/layout.tsx
@@ -134,7 +134,7 @@ export function Footer({ withNavigation }: FooterProps) {
           rel="noreferrer"
           data-umami-event="click-footer-bsky-link"
         >
-          <BlueskyIcon className="size-7 text-base-100" />
+          <BlueskyIcon className="size-7 text-white" />
         </a>
         <a
           href="https://github.com/mkizka/linkat"
@@ -142,7 +142,7 @@ export function Footer({ withNavigation }: FooterProps) {
           rel="noreferrer"
           data-umami-event="click-footer-github-link"
         >
-          <GitHubIcon className="size-7 text-base-100" />
+          <GitHubIcon className="size-7 text-white" />
         </a>
         <div className="relative size-7">
           <div className="loading loading-spinner absolute top-1.5 size-4"></div>

--- a/app/features/board/card/profile-card.tsx
+++ b/app/features/board/card/profile-card.tsx
@@ -79,7 +79,7 @@ export function ProfileCard({ user, url, showEditButton }: ProfileCardProps) {
               </Link>
             ) : (
               <a
-                className="btn-bluesky btn text-base-100"
+                className="btn-bluesky btn text-white"
                 href={`https://bsky.app/profile/${user.handle}`}
                 target="_blank"
                 rel="noreferrer"

--- a/app/features/board/share-modal.tsx
+++ b/app/features/board/share-modal.tsx
@@ -85,7 +85,7 @@ export function ShareModal({ url }: Props) {
           <p>{t("share-modal.description")}</p>
           <div className="flex flex-col gap-4 py-4 sm:flex-row">
             <Button
-              className="btn-bluesky btn flex-1 text-base-100"
+              className="btn-bluesky btn flex-1 text-white"
               loading={loading}
               onClick={handlePost}
             >

--- a/app/features/login/login-form.tsx
+++ b/app/features/login/login-form.tsx
@@ -72,7 +72,7 @@ export function LoginForm() {
         )}
         <Button
           type="submit"
-          className="btn-bluesky text-base-100"
+          className="btn-bluesky text-blue-100"
           loading={navigation.state !== "idle"}
           data-testid="login-form__submit"
         >

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -59,7 +59,7 @@ export default function Index({ loaderData }: Route.ComponentProps) {
             ) : (
               <Link
                 to="/login"
-                className="btn-bluesky btn w-64 text-base-100"
+                className="btn-bluesky btn w-64 text-blue-100"
                 data-testid="index__login-link"
               >
                 <AtSymbolIcon className="-ml-4 size-6" />


### PR DESCRIPTION
## 概要

[Blueskyブランドガイドライン](https://bsky.social/about/support/branding)への準拠を確認した際に見つかった、ダークモードでの配色問題を修正します。

## 問題

`text-base-100` はdaisyUIのダークテーマで暗色(#1d232a付近)になるため、ダークモードで以下の問題がありました。

- footerの蝶・GitHubアイコンが背景(`bg-neutral`)に溶けてほぼ見えない
- 青ボタン(`btn-bluesky`)上の文字・蝶アイコンが暗灰色になる

また、Blueskyの蝶ロゴはブランドガイドラインで白/青/黒のみが許可されており、暗灰色での表示はガイドライン違反でもありました。

## 変更内容

| 箇所 | 変更 |
|---|---|
| footerの蝶・GitHubアイコン (`layout.tsx`) | `text-base-100` → `text-white` |
| シェアモーダルの「Blueskyにポストする」ボタン (`share-modal.tsx`) | `text-base-100` → `text-white` |
| プロフィールカードの「Bluesky」ボタン (`profile-card.tsx`) | `text-base-100` → `text-white` |
| トップのログインリンク (`_index.tsx`) | `text-base-100` → `text-blue-100` |
| ログイン送信ボタン (`login-form.tsx`) | `text-base-100` → `text-blue-100` |

蝶ロゴを含むボタンはガイドライン準拠のため白固定、ロゴを含まないログインボタンはまぶしさを抑えるため少し落とした `text-blue-100` にしています。

ライトモードでは `base-100` ≒ 白のため、見た目はほぼ変わりません。

## 確認方法

DevTools → Rendering → 「Emulate CSS media feature prefers-color-scheme」で `dark` に切り替えて以下を確認:

- `/` … footerのアイコン2つが白く見える、ログインボタンの文字が読める
- `/login` … ログインボタンの文字が読める
- `/sample` … 「Bluesky」ボタンの蝶と文字が白い
- `/{handle}?success` … シェアモーダルのボタンの蝶と文字が白い

🤖 Generated with [Claude Code](https://claude.com/claude-code)