### PR TITLE
Return 404 for unmatched paths

### DIFF
--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,0 +1,3 @@
+export function loader() {
+  throw new Response("Not Found", { status: 404 });
+}

--- a/e2e/not-found.spec.ts
+++ b/e2e/not-found.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("存在しないパス", () => {
+  test("マッチするルートがない場合は404を返す", async ({ page }) => {
+    const response = await page.goto("/.well-known/oauth-authorization-server");
+    expect(response?.status()).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Railwayの本番ログを確認したところ、5xxエラーの大半が`.well-known/*`や存在しないパスへのアクセス（bot・クローラー・脆弱性スキャナー等）で発生していました。

原因は、ファイルベースルーティングでどのルートにもマッチしないリクエストが来た場合、`root.tsx`の`i18nextMiddleware`が実行されないまま`entry.server.tsx`が`getInstance(loadContext)`を呼び出し、`No value found for context`エラーで落ちていたためです。本来404になるべきアクセスがすべて500として記録されていました。

`app/routes/$.tsx`（catch-all/splatルート）を追加し、未定義パスに対して明示的に404を返すようにしました。これによりミドルウェアチェーンが正しく実行されます。

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] ローカルdevサーバーで`.well-known/*`が500→404になることを確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)