### PR TITLE
Add JetstreamCursor table for cursor persistence

### DIFF
--- a/prisma/migrations/20260905142549_add_jetstream_cursor/migration.sql
+++ b/prisma/migrations/20260905142549_add_jetstream_cursor/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "JetstreamCursor" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "cursor" BIGINT NOT NULL,
+
+    CONSTRAINT "JetstreamCursor_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,7 +48,6 @@ model AuthState {
   state String
 }
 
-// Jetstream再接続時に取りこぼしなく再開するための購読位置
 model JetstreamCursor {
   id     Int    @id @default(1)
   cursor BigInt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,3 +47,9 @@ model AuthState {
   key   String @id
   state String
 }
+
+// Jetstream再接続時に取りこぼしなく再開するための購読位置
+model JetstreamCursor {
+  id     Int    @id @default(1)
+  cursor BigInt
+}


### PR DESCRIPTION
## 概要

Jetstreamの購読再開位置(cursor)を保存する`JetstreamCursor`テーブルを追加する。

Closes #322

## 影響範囲

テーブル追加のみで、参照するコードはまだない。既存動作への影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FVJBxUbrMKugd6mGYPxcU