### PR TITLE
Enable trust proxy to fix login CSRF check

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -21,6 +21,9 @@ const viteDevServer =
       );
 
 const app = express();
+// RailwayのエッジでTLS終端されるため、X-Forwarded-Protoを信頼しないとreq.protocolが常にhttpになり、
+// react-routerのCSRFチェック(Origin: httpsとrequest.url: httpの不一致)でログインが400になる
+app.set("trust proxy", true);
 
 app.use(
   pinoHttp({


### PR DESCRIPTION
## 概要

Production環境で `/login.data` へのPOSTが全て `400 Bad Request` になり、ログインができなくなっていた問題を修正します。

## 原因

RailwayのエッジでTLS終端されるため、アプリへのリクエストは常にHTTPで転送されます。Expressの `trust proxy` が未設定だと `req.protocol` が常に `http` になり、`@react-router/express` が構築する `request.url` のオリジンが `http://linkat.blue` になっていました。

一方ブラウザが送る `Origin` ヘッダーは `https://linkat.blue` のため、React Router v7 (single fetch) のCSRF保護 (`throwIfPotentialCSRFAttack`) がこの不一致を検知して `Bad Request` を返していました。

## 対応

`app/server.ts` に `app.set("trust proxy", true)` を追加し、`X-Forwarded-Proto` を信頼するようにしました。