### PR TITLE
Fix findOrFetchUser to fall back to DID resolution when getProfile fails

### DIFF
--- a/app/server/service/didService/did.ts
+++ b/app/server/service/didService/did.ts
@@ -1,5 +1,5 @@
 import type { DidDocument } from "@atproto/identity";
-import { IdResolver } from "@atproto/identity";
+import { getHandle, IdResolver } from "@atproto/identity";
 
 import { env } from "~/utils/env";
 import { createLogger } from "~/utils/logger";
@@ -33,4 +33,18 @@ export const resolveServiceUrl = async (userDid: string) => {
     return null;
   }
   return serviceUrl;
+};
+
+export const resolveHandle = async (userDid: string) => {
+  const didDocument = await resolver.did.resolve(userDid);
+  if (!didDocument) {
+    logger.warn({ userDid }, "DIDの解決に失敗しました");
+    return null;
+  }
+  const handle = getHandle(didDocument);
+  if (!handle) {
+    logger.warn({ didDocument }, "DID解決後にhandleが取得できませんでした");
+    return null;
+  }
+  return handle;
 };

--- a/app/server/service/userService/user.spec.ts
+++ b/app/server/service/userService/user.spec.ts
@@ -146,6 +146,10 @@ describe("userService", () => {
           "https://public.api.example.com/xrpc/app.bsky.actor.getProfile",
           () => HttpResponse.json("", { status: 500 }),
         ),
+        http.get(
+          "https://public.api.example.com/xrpc/com.atproto.identity.resolveHandle",
+          () => HttpResponse.json("", { status: 500 }),
+        ),
       );
       // act
       const actual = await userService.findOrFetchUser({
@@ -153,6 +157,37 @@ describe("userService", () => {
       });
       // assert
       expect(actual).toBeNull();
+    });
+    test("DBにユーザーがなく、getProfileが失敗してもDIDが解決できればhandleのみのユーザーを作成する", async () => {
+      // arrange
+      server.use(
+        http.get(
+          "https://public.api.example.com/xrpc/app.bsky.actor.getProfile",
+          () => HttpResponse.json("Profile not found", { status: 400 }),
+        ),
+        http.get(
+          `https://plc.example.com/${encodeURIComponent("did:plc:dfbe2uvzisfdxwscnwcxdta6")}`,
+          () =>
+            HttpResponse.json({
+              id: "did:plc:dfbe2uvzisfdxwscnwcxdta6",
+              alsoKnownAs: ["at://example.com"],
+            }),
+        ),
+      );
+      // act
+      const actual = await userService.findOrFetchUser({
+        handleOrDid: "did:plc:dfbe2uvzisfdxwscnwcxdta6",
+      });
+      // assert
+      expect(actual).toEqual({
+        avatar: null,
+        description: null,
+        displayName: null,
+        did: "did:plc:dfbe2uvzisfdxwscnwcxdta6",
+        handle: "example.com",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
     });
     test("入力が明らかにドメインでなければnullを返す", async () => {
       // arrange

--- a/app/server/service/userService/user.ts
+++ b/app/server/service/userService/user.ts
@@ -37,14 +37,8 @@ const findUser = async ({
 
 type MinimalProfile = Pick<
   AppBskyActorDefs.ProfileViewDetailed,
-  "did" | "handle"
-> &
-  Partial<
-    Pick<
-      AppBskyActorDefs.ProfileViewDetailed,
-      "avatar" | "description" | "displayName"
-    >
-  >;
+  "did" | "handle" | "avatar" | "description" | "displayName"
+>;
 
 const createOrUpdateUser = async ({
   tx,
@@ -55,9 +49,9 @@ const createOrUpdateUser = async ({
 }) => {
   const data = {
     did: blueskyProfile.did,
-    avatar: blueskyProfile.avatar ?? null,
-    description: blueskyProfile.description ?? null,
-    displayName: blueskyProfile.displayName ?? null,
+    avatar: blueskyProfile.avatar,
+    description: blueskyProfile.description,
+    displayName: blueskyProfile.displayName,
     handle: blueskyProfile.handle,
   } satisfies Prisma.UserUpsertArgs["create"];
   return await tx.user.upsert({

--- a/app/server/service/userService/user.ts
+++ b/app/server/service/userService/user.ts
@@ -3,6 +3,7 @@ import { isDid } from "@atproto/did";
 import type { Prisma, User } from "@prisma/client";
 
 import { LinkatAgent } from "~/libs/agent";
+import { didService } from "~/server/service/didService";
 import { prisma } from "~/server/service/prisma";
 import { env } from "~/utils/env";
 import { createLogger } from "~/utils/logger";
@@ -34,18 +35,29 @@ const findUser = async ({
   return user;
 };
 
+type MinimalProfile = Pick<
+  AppBskyActorDefs.ProfileViewDetailed,
+  "did" | "handle"
+> &
+  Partial<
+    Pick<
+      AppBskyActorDefs.ProfileViewDetailed,
+      "avatar" | "description" | "displayName"
+    >
+  >;
+
 const createOrUpdateUser = async ({
   tx,
   blueskyProfile,
 }: {
   tx: Prisma.TransactionClient;
-  blueskyProfile: AppBskyActorDefs.ProfileViewDetailed;
+  blueskyProfile: MinimalProfile;
 }) => {
   const data = {
     did: blueskyProfile.did,
-    avatar: blueskyProfile.avatar,
-    description: blueskyProfile.description,
-    displayName: blueskyProfile.displayName,
+    avatar: blueskyProfile.avatar ?? null,
+    description: blueskyProfile.description ?? null,
+    displayName: blueskyProfile.displayName ?? null,
     handle: blueskyProfile.handle,
   } satisfies Prisma.UserUpsertArgs["create"];
   return await tx.user.upsert({
@@ -66,6 +78,23 @@ const fetchBlueskyProfile = async (handleOrDid: string) => {
   return response.data;
 };
 
+// app.bsky.actor.profileレコードが存在しないアカウントはgetProfileが失敗するため、
+// DID解決だけでdid/handleを補って最低限のユーザーを作成する
+const fetchMinimalProfile = async (
+  handleOrDid: string,
+): Promise<MinimalProfile> => {
+  if (isDid(handleOrDid)) {
+    const handle = await didService.resolveHandle(handleOrDid);
+    if (!handle) {
+      throw new Error(`handleを解決できませんでした: ${handleOrDid}`);
+    }
+    return { did: handleOrDid, handle };
+  }
+  const agent = LinkatAgent.credential(env.BSKY_PUBLIC_API_URL);
+  const response = await agent.resolveHandle({ handle: handleOrDid });
+  return { did: response.data.did, handle: handleOrDid };
+};
+
 export const findOrFetchUser = async ({
   tx = prisma,
   handleOrDid,
@@ -83,7 +112,15 @@ export const findOrFetchUser = async ({
   const blueskyProfile = await tryCatch(fetchBlueskyProfile)(handleOrDid);
   if (blueskyProfile instanceof Error) {
     logger.warn(blueskyProfile, "プロフィールの取得に失敗しました");
-    return user;
+    if (user) {
+      return user;
+    }
+    const minimalProfile = await tryCatch(fetchMinimalProfile)(handleOrDid);
+    if (minimalProfile instanceof Error) {
+      logger.warn(minimalProfile, "最低限のユーザー作成にも失敗しました");
+      return null;
+    }
+    return await createOrUpdateUser({ tx, blueskyProfile: minimalProfile });
   }
   return await createOrUpdateUser({
     tx,


### PR DESCRIPTION
## 概要

issue #331 の修正。`app.bsky.actor.profile` レコードを作成していない（または未インデックスの）Blueskyアカウントは、`findOrFetchUser` 内の `getProfile` が失敗し、DB未登録の場合に `null` が返っていました。その結果ログインには成功するものの `/edit` や `/$handle` にアクセスできませんでした。

`getProfile` が失敗しDBにも既存ユーザーがいない場合、DID解決（`didService.resolveHandle` / `resolveHandle` XRPC）でdid/handleのみを補い、最低限のユーザーレコードを作成するようにしました。

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWfud3VByMSuieWN58Cnu2