### PR TITLE
Use real PDS instead of local atproto dev-env for dev and e2e

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 # prisma
 DATABASE_URL=postgresql://postgres:password@localhost:5432/linkat
+
+# e2e
+E2E_HANDLE=e2e-test.pds.mkizka.dev
+E2E_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@
 DATABASE_URL=postgresql://postgres:password@localhost:5432/linkat
 
 # e2e
-E2E_HANDLE=e2e-test.pds.mkizka.dev
+E2E_HANDLE=
 E2E_PASSWORD=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,9 @@ jobs:
       - run: pnpm setup-dev
       - run: pnpm build
       - run: pnpm e2e
+        env:
+          E2E_HANDLE: ${{ secrets.E2E_HANDLE }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
       # https://www.cloudflarestatus.com/incidents/t5nrjmpxc1cj
       - uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # 1.0.8
         if: always() && (github.ref == 'refs/heads/main' || github.actor == 'mkizka')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - run: pnpm test -- --coverage
   e2e-test:
     runs-on: ubuntu-latest
+    concurrency:
+      group: e2e-test
+      cancel-in-progress: false
     permissions:
       pull-requests: write
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ pnpm prisma generate
 
 - `DATABASE_URL`: PostgreSQL接続文字列
 - `PRIVATE_JETSTREAM_URL`: JetstreamサービスURL
-- `ORIGIN`: アプリケーションURL (開発環境: http://linkat.localhost:3000)
+- `ORIGIN`: アプリケーションURL (開発環境: http://localhost:3000)
 
 ### エラーハンドリング
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ pnpm install
 pnpm dev
 ```
 
-This connects to the real Bluesky network (no local PDS is started), so log in with a real Bluesky account.
-
 After running the commands, open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ pnpm install
 pnpm dev
 ```
 
-This connects to the real Bluesky network (no local PDS is started), so OAuth login requires HTTPS access to `http://localhost:3000`. Set up a tunnel (e.g. Cloudflare Tunnel, ngrok) and override `PUBLIC_URL` in `.env` to point to it.
+This connects to the real Bluesky network (no local PDS is started), so log in with a real Bluesky account.
 
-After running the commands, open your `PUBLIC_URL` in your browser.
+After running the commands, open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ pnpm install
 pnpm dev
 ```
 
-After running the commands, open [http://linkat.localhost:3000](http://linkat.localhost:3000) in your browser.
+This connects to the real Bluesky network (no local PDS is started), so OAuth login requires HTTPS access to `http://localhost:3000`. Set up a tunnel (e.g. Cloudflare Tunnel, ngrok) and override `PUBLIC_URL` in `.env` to point to it.
+
+After running the commands, open your `PUBLIC_URL` in your browser.
 
 ## Contributing
 

--- a/app/server.ts
+++ b/app/server.ts
@@ -57,7 +57,7 @@ if (viteDevServer) {
 }
 
 // 開発環境でのOAuthログイン時 http://127.0.0.1/oauth/callback にリダイレクトされるので、
-// そこからさらに http://linkat.localhost にリダイレクトさせる
+// そこからさらに env.PUBLIC_URL (開発環境: http://localhost:3000) にリダイレクトさせる
 app.use((req, res, next) => {
   if (env.NODE_ENV === "development" && req.hostname === "127.0.0.1") {
     res.redirect(new URL(req.originalUrl, env.PUBLIC_URL).toString());

--- a/app/utils/env.ts
+++ b/app/utils/env.ts
@@ -29,7 +29,6 @@ const server = {
   PRIVATE_KEY_ES256_B64: isProduction
     ? z.string()
     : z.string().default(DEVELOPMENT_PRIVATE_KEY),
-  // 開発環境も実PDS/実ネットワークに繋ぐため本番と同じ値をデフォルトにする
   BSKY_PUBLIC_API_URL: z.url().default("https://public.api.bsky.app"),
   JETSTREAM_URL: z
     .url()

--- a/app/utils/env.ts
+++ b/app/utils/env.ts
@@ -18,11 +18,11 @@ const server = {
     .enum(["debug", "info", "warn", "error"])
     .default(match({ prod: "info", dev: "debug" })),
   DATABASE_URL: z.string(),
-  // 開発環境でのOAuthログイン時にlocalhost:2583にリダイレクトされるが、
-  // ドメインが同じだとOAuthログインに失敗するためlinkat.localhostを使う
+  // 開発環境でも実PDSに対してOAuthログインするため、Cloudflare tunnel経由でHTTPSアクセス出来る
+  // localhost-3000.mkizka.devをデフォルトにする
   PUBLIC_URL: isProduction
     ? z.string()
-    : z.string().default("http://linkat.localhost:3000"),
+    : z.string().default("https://localhost-3000.mkizka.dev"),
   // openssl rand -base64 33
   COOKIE_SECRET: isProduction
     ? z.string()
@@ -31,26 +31,14 @@ const server = {
   PRIVATE_KEY_ES256_B64: isProduction
     ? z.string()
     : z.string().default(DEVELOPMENT_PRIVATE_KEY),
-  BSKY_PUBLIC_API_URL: z.url().default(
-    match({
-      prod: "https://public.api.bsky.app",
-      dev: "http://localhost:2584",
-    }),
-  ),
-  JETSTREAM_URL: z.url().default(
-    match({
-      prod: "wss://jetstream1.us-west.bsky.network/subscribe",
-      dev: "ws://localhost:6008/subscribe",
-    }),
-  ),
+  // 開発環境も実PDS/実ネットワークに繋ぐため本番と同じ値をデフォルトにする
+  BSKY_PUBLIC_API_URL: z.url().default("https://public.api.bsky.app"),
+  JETSTREAM_URL: z
+    .url()
+    .default("wss://jetstream1.us-west.bsky.network/subscribe"),
   // PR環境などJetstreamを使わない場合に無効化出来るようにする
   DISABLE_JETSTREAM: z.coerce.boolean().default(false),
-  ATPROTO_PLC_URL: z.url().default(
-    match({
-      prod: "https://plc.directory",
-      dev: "http://localhost:2582",
-    }),
-  ),
+  ATPROTO_PLC_URL: z.url().default("https://plc.directory"),
   UMAMI_SCRIPT_URL: z.string().optional(),
   UMAMI_WEBSITE_ID: z.string().optional(),
   // aboutページで使用するwhitewindの記事情報

--- a/app/utils/env.ts
+++ b/app/utils/env.ts
@@ -18,11 +18,9 @@ const server = {
     .enum(["debug", "info", "warn", "error"])
     .default(match({ prod: "info", dev: "debug" })),
   DATABASE_URL: z.string(),
-  // 開発環境でも実PDSに対してOAuthログインするため、Cloudflare tunnel経由でHTTPSアクセス出来る
-  // localhost-3000.mkizka.devをデフォルトにする
   PUBLIC_URL: isProduction
     ? z.string()
-    : z.string().default("https://localhost-3000.mkizka.dev"),
+    : z.string().default("http://localhost:3000"),
   // openssl rand -base64 33
   COOKIE_SECRET: isProduction
     ? z.string()

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,9 +15,3 @@ services:
       interval: 2s
       timeout: 2s
       retries: 10
-  jetstream:
-    image: ghcr.io/bluesky-social/jetstream:sha-011b545
-    network_mode: host
-    environment:
-      - JETSTREAM_WS_URL=ws://localhost:2583/xrpc/com.atproto.sync.subscribeRepos
-      - JETSTREAM_WORKER_COUNT=1

--- a/e2e/edit-redirect.spec.ts
+++ b/e2e/edit-redirect.spec.ts
@@ -16,7 +16,7 @@ test.describe("編集(リダイレクト)", () => {
         name: "__session",
         value:
           "eyJkaWQiOiJkaWQ6cGxjOnRpd2h6NWdiZTVqZGt2cmdjbHB1Z2oybCJ9.09GaE2lRKbto%2FraoDdda4pGnsQNvsIRfuBHErKE1qU",
-        domain: "linkat.localhost",
+        domain: "localhost",
         path: "/",
       },
     ]);

--- a/e2e/edit.spec.ts
+++ b/e2e/edit.spec.ts
@@ -1,15 +1,21 @@
 import { expect, test } from "@playwright/test";
 
+const E2E_HANDLE = process.env.E2E_HANDLE;
+const E2E_PASSWORD = process.env.E2E_PASSWORD;
+if (!E2E_HANDLE || !E2E_PASSWORD) {
+  throw new Error("環境変数E2E_HANDLE, E2E_PASSWORDを設定してください");
+}
+
 test.describe("編集", () => {
   test("カードの編集操作を一通り確認", async ({ page }) => {
     page.on("dialog", (dialog) => dialog.accept());
 
     await test.step("ログイン", async () => {
       await page.goto("/login");
-      await page.getByTestId("login-form__identifier").fill("alice.test");
+      await page.getByTestId("login-form__identifier").fill(E2E_HANDLE);
       await page.getByTestId("login-form__submit").click();
       await page.waitForURL((url) => url.pathname === "/oauth/authorize");
-      await page.locator("[name='password']").fill("hunter2");
+      await page.locator("[name='password']").fill(E2E_PASSWORD);
       await page.locator("button", { hasText: "Sign in" }).click();
       await page.locator("button", { hasText: "Authorize" }).click();
       await page.waitForURL((url) => url.pathname === "/edit");

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "build:remix": "react-router build",
     "build:server": "node ./scripts/build-server.js",
     "dev": "./scripts/dev.sh | pino-pretty",
-    "dev-atproto": "./scripts/dev-atproto.sh",
     "e2e": "playwright test",
     "format": "pnpm _eslint --fix && prettier . --write",
     "postinstall": "./scripts/postinstall.sh",
@@ -18,7 +17,7 @@
     "prepare": "husky",
     "setup-dev": "./scripts/setup-dev.sh",
     "start": "NODE_ENV=production node ./dist/server.js",
-    "start:local": "NODE_ENV=development E2E=1 node --env-file .env ./dist/server.js",
+    "start:local": "NODE_ENV=development E2E=1 PUBLIC_URL=http://localhost:3000 DISABLE_JETSTREAM=true node --env-file .env ./dist/server.js",
     "test": "vitest run",
     "typecheck": "react-router typegen && tsc"
   },
@@ -107,8 +106,7 @@
     "vite": "8.2.2",
     "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.11",
-    "vitest-mock-extended": "5.1.1",
-    "wait-on": "9.1.0"
+    "vitest-mock-extended": "5.1.1"
   },
   "sideEffects": false,
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "husky",
     "setup-dev": "./scripts/setup-dev.sh",
     "start": "NODE_ENV=production node ./dist/server.js",
-    "start:local": "NODE_ENV=development E2E=1 PUBLIC_URL=http://localhost:3000 DISABLE_JETSTREAM=true node --env-file .env ./dist/server.js",
+    "start:local": "NODE_ENV=development E2E=1 DISABLE_JETSTREAM=true node --env-file .env ./dist/server.js",
     "test": "vitest run",
     "typecheck": "react-router typegen && tsc"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig } from "@playwright/test";
 
+try {
+  process.loadEnvFile(".env");
+} catch {
+  // .envが無い場合は環境変数が既に設定されている前提で無視する
+}
+
 export default defineConfig({
   testDir: "./e2e",
   outputDir: "./node_modules/.cache/playwright",
@@ -10,7 +16,7 @@ export default defineConfig({
     ["html", { open: "always" }],
   ],
   use: {
-    baseURL: "http://linkat.localhost:3000",
+    baseURL: "http://localhost:3000",
     video: "on",
     trace: "on",
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,9 +258,6 @@ importers:
       vitest-mock-extended:
         specifier: 5.1.1
         version: 5.1.1(typescript@6.0.3)(vitest@4.1.11)
-      wait-on:
-        specifier: 9.1.0
-        version: 9.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
 
 packages:
 
@@ -763,26 +760,6 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@hapi/address@5.1.1':
-    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
-    engines: {node: '>=14.0.0'}
-
-  '@hapi/formula@3.0.2':
-    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
-
-  '@hapi/hoek@11.0.7':
-    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
-
-  '@hapi/pinpoint@2.0.1':
-    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
-
-  '@hapi/tlds@1.1.6':
-    resolution: {integrity: sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==}
-    engines: {node: '>=14.0.0'}
-
-  '@hapi/topo@6.0.2':
-    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@heroicons/react@2.2.0':
     resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
@@ -1437,10 +1414,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1482,9 +1455,6 @@ packages:
   ast-v8-to-istanbul@1.0.2:
     resolution: {integrity: sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -1498,9 +1468,6 @@ packages:
 
   await-lock@3.0.0:
     resolution: {integrity: sha512-eO6fLiSnrJrMdjWMNK8zbVRXPs2TKJg78iKZd9wDpN3na5tcoV6EoeiOlMgk2QaAQ1gIrK1YuMsJHXWqz89tSA==}
-
-  axios@1.19.0:
-    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -1636,10 +1603,6 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1777,10 +1740,6 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1860,10 +1819,6 @@ packages:
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.28.2:
@@ -2097,19 +2052,6 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
-  form-data@4.0.6:
-    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
-    engines: {node: '>= 6'}
-
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -2206,10 +2148,6 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -2233,10 +2171,6 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -2352,10 +2286,6 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
-
-  joi@18.2.3:
-    resolution: {integrity: sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==}
-    engines: {node: '>= 20'}
 
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
@@ -2925,10 +2855,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
-
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3117,9 +3043,6 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -3597,11 +3520,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  wait-on@9.1.0:
-    resolution: {integrity: sha512-PymrLXHLBM1Ju/Xspb2ADUhbPSMvbnuNvy/mN2hWtpbJ3da0h3Ky1LqwKPG5QSVR57liyO0iUpfipYl/s5qNvA==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4271,22 +4189,6 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hapi/address@5.1.1':
-    dependencies:
-      '@hapi/hoek': 11.0.7
-
-  '@hapi/formula@3.0.2': {}
-
-  '@hapi/hoek@11.0.7': {}
-
-  '@hapi/pinpoint@2.0.1': {}
-
-  '@hapi/tlds@1.1.6': {}
-
-  '@hapi/topo@6.0.2':
-    dependencies:
-      '@hapi/hoek': 11.0.7
-
   '@heroicons/react@2.2.0(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -4936,12 +4838,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2(supports-color@7.2.0):
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4980,8 +4876,6 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  asynckit@0.4.0: {}
-
   atomic-sleep@1.0.0: {}
 
   autoprefixer@10.5.4(postcss@8.5.26):
@@ -4994,16 +4888,6 @@ snapshots:
       postcss-value-parser: 4.2.0
 
   await-lock@3.0.0: {}
-
-  axios@1.19.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1(supports-color@7.2.0)
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   babel-dead-code-elimination@1.0.12(supports-color@7.2.0):
     dependencies:
@@ -5165,10 +5049,6 @@ snapshots:
 
   colorette@2.0.20: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@4.1.1: {}
 
   commander@9.5.0: {}
@@ -5265,8 +5145,6 @@ snapshots:
 
   defu@6.1.7: {}
 
-  delayed-stream@1.0.0: {}
-
   depd@2.0.0: {}
 
   destr@2.0.5: {}
@@ -5323,13 +5201,6 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -5724,18 +5595,6 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-
-  form-data@4.0.6:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.4
-      mime-types: 2.1.35
-
   forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
@@ -5817,10 +5676,6 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -5845,13 +5700,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-
-  https-proxy-agent@5.0.1(supports-color@7.2.0):
-    dependencies:
-      agent-base: 6.0.2(supports-color@7.2.0)
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
 
   husky@9.1.7: {}
 
@@ -5931,16 +5779,6 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.7.0: {}
-
-  joi@18.2.3:
-    dependencies:
-      '@hapi/address': 5.1.1
-      '@hapi/formula': 3.0.2
-      '@hapi/hoek': 11.0.7
-      '@hapi/pinpoint': 2.0.1
-      '@hapi/tlds': 1.1.6
-      '@hapi/topo': 6.0.2
-      '@standard-schema/spec': 1.1.0
 
   jose@5.10.0: {}
 
@@ -6430,8 +6268,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@2.1.0: {}
-
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -6590,10 +6426,6 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  rxjs@7.8.2:
-    dependencies:
-      tslib: 2.8.1
 
   safe-buffer@5.2.1: {}
 
@@ -7039,17 +6871,6 @@ snapshots:
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
     transitivePeerDependencies:
       - msw
-
-  wait-on@9.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
-    dependencies:
-      axios: 1.19.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
-      joi: 18.2.3
-      lodash: 4.18.1
-      minimist: 1.2.8
-      rxjs: 7.8.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   which@2.0.2:
     dependencies:

--- a/scripts/dev-atproto.sh
+++ b/scripts/dev-atproto.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ATPROTO_COMMIT=$(cat .atproto-version)
-ATPROTO_DIR="$HOME/.cache/atproto/$ATPROTO_COMMIT"
-
-cd "$ATPROTO_DIR" && make run-dev-env

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,29 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ATPROTO_COMMIT=$(cat .atproto-version)
-ATPROTO_DIR="$HOME/.cache/atproto/$ATPROTO_COMMIT"
-
-# 1. Setup atproto dev server
-if [ ! -d "$ATPROTO_DIR/node_modules" ]; then
-  cd "$ATPROTO_DIR"
-  make deps
-  make build
-  cd -
-fi
-
-# 2. Start atproto dev server
-nohup pnpm dev-atproto &
-pid=$!
-echo "Started atproto dev server with pid $pid"
-trap "
-echo
-echo 'kill -STOP $pid && docker compose down'
-kill $pid
-docker compose down
-exit
-" SIGINT SIGTERM
-
-# 3. Setup database and jetstream
-pnpm wait-on tcp:2583 && docker compose up -d --wait
+docker compose up -d --wait
 pnpm prisma migrate deploy


### PR DESCRIPTION
## 概要

ローカルのatproto dev-env(docker composeでPDS/plc/bsky/jetstreamを起動する仕組み)をやめて、開発・e2eテストとも本物のPDSに接続するようにしました。

- e2eテストは`E2E_HANDLE`/`E2E_PASSWORD`で注入する実アカウントでログインする
- 不要になったローカルdev-env関連のスクリプト・依存を削除
- 実アカウントを共有するため、e2e-testジョブはPR間で同時実行しないようにした

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZ8aoGu43xLRFL6YtVbCY3