### PR TITLE
Migrate LinkatAgent from @atproto/api to @atproto/lex Client

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,8 +8,7 @@ coverage/
 
 # atproto
 generated/
-atproto/
-lexicons/com/
+/atproto/
 
 # playwright
 playwright-report/

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,6 @@ coverage/
 
 # atproto
 generated/
-/atproto/
 
 # playwright
 playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ coverage/
 
 # atproto
 generated/
-atproto/
+/atproto/
 nohup.out
 
 # playwright

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ coverage/
 
 # atproto
 generated/
-/atproto/
 nohup.out
 
 # playwright

--- a/app/features/board/card/bluesky-feed.tsx
+++ b/app/features/board/card/bluesky-feed.tsx
@@ -2,8 +2,9 @@ import { asAtUriString } from "@atproto/syntax";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { $OutputBody } from "~/generated/app/bsky/feed/getFeedGenerator";
-import getFeedGenerator from "~/generated/app/bsky/feed/getFeedGenerator";
+import getFeedGenerator, {
+  type $OutputBody,
+} from "~/generated/app/bsky/feed/getFeedGenerator";
 import { LinkatAgent } from "~/libs/agent";
 
 type Props = {

--- a/app/features/board/card/bluesky-feed.tsx
+++ b/app/features/board/card/bluesky-feed.tsx
@@ -1,7 +1,9 @@
-import type { AppBskyFeedGetFeedGenerator } from "@atproto/api";
+import type { AtUriString } from "@atproto/lex";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { $OutputBody } from "~/generated/app/bsky/feed/getFeedGenerator";
+import getFeedGenerator from "~/generated/app/bsky/feed/getFeedGenerator";
 import { LinkatAgent } from "~/libs/agent";
 
 type Props = {
@@ -11,16 +13,18 @@ type Props = {
 
 export function BlueskyFeed({ feedUri, url }: Props) {
   const { t } = useTranslation();
-  const [feed, setFeed] =
-    useState<AppBskyFeedGetFeedGenerator.OutputSchema | null>(null);
+  const [feed, setFeed] = useState<$OutputBody | null>(null);
   const [showError, setShowError] = useState(false);
 
   useEffect(() => {
     const agent = LinkatAgent.credential();
-    agent.app.bsky.feed
-      .getFeedGenerator({ feed: feedUri })
+    agent
+      .call(getFeedGenerator, {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        feed: feedUri as AtUriString,
+      })
       .then((response) => {
-        setFeed(response.data);
+        setFeed(response);
       })
       .catch((error: unknown) => {
         // eslint-disable-next-line no-console

--- a/app/features/board/card/bluesky-feed.tsx
+++ b/app/features/board/card/bluesky-feed.tsx
@@ -1,4 +1,4 @@
-import type { AtUriString } from "@atproto/lex";
+import { asAtUriString } from "@atproto/syntax";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -19,10 +19,7 @@ export function BlueskyFeed({ feedUri, url }: Props) {
   useEffect(() => {
     const agent = LinkatAgent.credential();
     agent
-      .call(getFeedGenerator, {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        feed: feedUri as AtUriString,
-      })
+      .call(getFeedGenerator, { feed: asAtUriString(feedUri) })
       .then((response) => {
         setFeed(response);
       })

--- a/app/libs/agent.ts
+++ b/app/libs/agent.ts
@@ -20,7 +20,6 @@ export class LinkatAgent extends Client {
   }
 
   async updateBoard(board: unknown) {
-    // blue.linkat.profile.boardにはなぜかputがないので、com.atproto.repoを使う
     return await this.putRecord(
       { $type: boardLexicon.$type, ...boardScheme.parse(board) },
       "self",

--- a/app/libs/agent.ts
+++ b/app/libs/agent.ts
@@ -1,5 +1,5 @@
-import type { AtIdentifierString } from "@atproto/lex";
 import { Client } from "@atproto/lex";
+import { asAtIdentifierString } from "@atproto/syntax";
 
 import boardLexicon from "~/generated/blue/linkat/board";
 import { boardScheme } from "~/models/board";
@@ -11,8 +11,7 @@ export class LinkatAgent extends Client {
 
   async getBoard(params: { repo: string }) {
     return await this.getRecord(boardLexicon.$type, "self", {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      repo: params.repo as AtIdentifierString,
+      repo: asAtIdentifierString(params.repo),
     });
   }
 

--- a/app/libs/agent.ts
+++ b/app/libs/agent.ts
@@ -1,23 +1,18 @@
-import { Agent, CredentialSession } from "@atproto/api";
+import type { AtIdentifierString } from "@atproto/lex";
+import { Client } from "@atproto/lex";
 
 import boardLexicon from "~/generated/blue/linkat/board";
 import { boardScheme } from "~/models/board";
 
-export class LinkatAgent extends Agent {
+export class LinkatAgent extends Client {
   static credential(serviceUrl: string = "https://public.api.bsky.app") {
-    const session = new CredentialSession(new URL(serviceUrl));
-    return new LinkatAgent(session);
-  }
-
-  async getSessionProfile() {
-    return await this.getProfile({ actor: this.assertDid });
+    return new LinkatAgent(serviceUrl);
   }
 
   async getBoard(params: { repo: string }) {
-    return await this.com.atproto.repo.getRecord({
-      ...params,
-      collection: boardLexicon.$type,
-      rkey: "self",
+    return await this.getRecord(boardLexicon.$type, "self", {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      repo: params.repo as AtIdentifierString,
     });
   }
 
@@ -27,20 +22,16 @@ export class LinkatAgent extends Agent {
 
   async updateBoard(board: unknown) {
     // blue.linkat.profile.boardにはなぜかputがないので、com.atproto.repoを使う
-    return await this.com.atproto.repo.putRecord({
-      repo: this.assertDid,
-      validate: false,
-      collection: boardLexicon.$type,
-      rkey: "self",
-      record: boardScheme.parse(board),
-    });
+    return await this.putRecord(
+      { $type: boardLexicon.$type, ...boardScheme.parse(board) },
+      "self",
+      { repo: this.assertDid, validate: false },
+    );
   }
 
   async deleteBoard() {
-    return await this.com.atproto.repo.deleteRecord({
+    return await this.deleteRecord(boardLexicon.$type, "self", {
       repo: this.assertDid,
-      collection: boardLexicon.$type,
-      rkey: "self",
     });
   }
 }

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,4 +1,4 @@
-import { AtUri } from "@atproto/api";
+import { AtUri } from "@atproto/syntax";
 import { LRUCache } from "lru-cache";
 import markdownit from "markdown-it";
 import { z } from "zod";
@@ -54,12 +54,10 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
     };
   }
   const agent = LinkatAgent.credential(env.ABOUT_WHTWND_PDS_URL);
-  const response = await agent.com.atproto.repo.getRecord({
+  const response = await agent.getRecord(atUri.collectionSafe, atUri.rkey, {
     repo: atUri.host,
-    collection: atUri.collection,
-    rkey: atUri.rkey,
   });
-  const whtwnd = whtwndSchema.parse(response.data.value);
+  const whtwnd = whtwndSchema.parse(response.body.value);
   const about = {
     title: whtwnd.title,
     content: md.render(whtwnd.content),

--- a/app/server/service/boardService/board.ts
+++ b/app/server/service/boardService/board.ts
@@ -72,7 +72,7 @@ const fetchBoardInPDS = async (userDid: string) => {
     logger.warn({ userDid, response }, "PDSからのboardの取得に失敗しました");
     return null;
   }
-  const parsed = boardScheme.safeParse(response.data.value);
+  const parsed = boardScheme.safeParse(response.body.value);
   if (!parsed.success) {
     logger.warn({ userDid, parsed }, "PDSからのboardの形式が不正でした");
     return null;

--- a/app/server/service/userService/user.spec.ts
+++ b/app/server/service/userService/user.spec.ts
@@ -1,6 +1,6 @@
-import type { AppBskyActorDefs } from "@atproto/api";
 import { http, HttpResponse } from "msw";
 
+import type { ProfileViewDetailed } from "~/generated/app/bsky/actor/defs";
 import { server } from "~/mocks/server";
 import { UserFactory } from "~/server/factories/user";
 
@@ -22,7 +22,7 @@ const dummyBlueskyProfile = {
   followersCount: 2,
   followsCount: 2,
   postsCount: 42,
-} satisfies AppBskyActorDefs.ProfileViewDetailed;
+} satisfies ProfileViewDetailed;
 
 describe("userService", () => {
   describe("findUser", () => {

--- a/app/server/service/userService/user.ts
+++ b/app/server/service/userService/user.ts
@@ -1,7 +1,9 @@
-import type { AppBskyActorDefs } from "@atproto/api";
 import { isDid } from "@atproto/did";
+import type { AtIdentifierString } from "@atproto/lex";
 import type { Prisma, User } from "@prisma/client";
 
+import type { ProfileViewDetailed } from "~/generated/app/bsky/actor/defs";
+import getProfile from "~/generated/app/bsky/actor/getProfile";
 import { LinkatAgent } from "~/libs/agent";
 import { prisma } from "~/server/service/prisma";
 import { env } from "~/utils/env";
@@ -39,7 +41,7 @@ const createOrUpdateUser = async ({
   blueskyProfile,
 }: {
   tx: Prisma.TransactionClient;
-  blueskyProfile: AppBskyActorDefs.ProfileViewDetailed;
+  blueskyProfile: ProfileViewDetailed;
 }) => {
   const data = {
     did: blueskyProfile.did,
@@ -60,10 +62,10 @@ const createOrUpdateUser = async ({
 const fetchBlueskyProfile = async (handleOrDid: string) => {
   logger.info({ actor: handleOrDid }, "プロフィールを取得します");
   const agent = LinkatAgent.credential(env.BSKY_PUBLIC_API_URL);
-  const response = await agent.getProfile({
-    actor: handleOrDid,
+  return await agent.call(getProfile, {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    actor: handleOrDid as AtIdentifierString,
   });
-  return response.data;
 };
 
 export const findOrFetchUser = async ({

--- a/app/server/service/userService/user.ts
+++ b/app/server/service/userService/user.ts
@@ -1,5 +1,5 @@
 import { isDid } from "@atproto/did";
-import type { AtIdentifierString } from "@atproto/lex";
+import { asAtIdentifierString } from "@atproto/syntax";
 import type { Prisma, User } from "@prisma/client";
 
 import type { ProfileViewDetailed } from "~/generated/app/bsky/actor/defs";
@@ -63,8 +63,7 @@ const fetchBlueskyProfile = async (handleOrDid: string) => {
   logger.info({ actor: handleOrDid }, "プロフィールを取得します");
   const agent = LinkatAgent.credential(env.BSKY_PUBLIC_API_URL);
   return await agent.call(getProfile, {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    actor: handleOrDid as AtIdentifierString,
+    actor: asAtIdentifierString(handleOrDid),
   });
 };
 

--- a/app/utils/url.ts
+++ b/app/utils/url.ts
@@ -1,3 +1,6 @@
+import type { HandleString } from "@atproto/lex";
+
+import resolveHandle from "~/generated/com/atproto/identity/resolveHandle";
 import { LinkatAgent } from "~/libs/agent";
 
 // https://bsky.app/profile/example.com
@@ -59,9 +62,12 @@ export const resolveHandleIfNeeded = async (original: string) => {
     return original;
   }
   const publicAgent = LinkatAgent.credential();
-  const response = await publicAgent.resolveHandle({ handle });
+  const response = await publicAgent.call(resolveHandle, {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    handle: handle as HandleString,
+  });
   const resolvedUrl = new URL(url.origin);
-  resolvedUrl.pathname = "/" + [profile, response.data.did, ...rest].join("/");
+  resolvedUrl.pathname = "/" + [profile, response.did, ...rest].join("/");
   return resolvedUrl.toString();
 };
 

--- a/app/utils/url.ts
+++ b/app/utils/url.ts
@@ -1,4 +1,4 @@
-import type { HandleString } from "@atproto/lex";
+import { ensureValidHandle } from "@atproto/syntax";
 
 import resolveHandle from "~/generated/com/atproto/identity/resolveHandle";
 import { LinkatAgent } from "~/libs/agent";
@@ -61,11 +61,9 @@ export const resolveHandleIfNeeded = async (original: string) => {
   if (!handle || handle.startsWith("did:")) {
     return original;
   }
+  ensureValidHandle(handle);
   const publicAgent = LinkatAgent.credential();
-  const response = await publicAgent.call(resolveHandle, {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    handle: handle as HandleString,
-  });
+  const response = await publicAgent.call(resolveHandle, { handle });
   const resolvedUrl = new URL(url.origin);
   resolvedUrl.pathname = "/" + [profile, response.did, ...rest].join("/");
   return resolvedUrl.toString();

--- a/lexicons.json
+++ b/lexicons.json
@@ -1,0 +1,102 @@
+{
+  "version": 1,
+  "lexicons": [
+    "app.bsky.actor.getProfile",
+    "app.bsky.feed.getFeedGenerator",
+    "com.atproto.identity.resolveHandle"
+  ],
+  "resolutions": {
+    "app.bsky.actor.defs": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.actor.defs",
+      "cid": "bafyreidv4wr3sla7dvnhdcxw6fkg4wst4njoifeysti7mmgflfhl36yxjq"
+    },
+    "app.bsky.actor.getProfile": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.actor.getProfile",
+      "cid": "bafyreigrtosreva7e5m7bwbbfsmw77gkdnieizgxwpobw5iobuck3j54xa"
+    },
+    "app.bsky.actor.status": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.actor.status",
+      "cid": "bafyreifdg4b64wohpwkh5lydc6tckvol2rspnpni6dec6recy2rhvlnz4a"
+    },
+    "app.bsky.embed.defs": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.defs",
+      "cid": "bafyreia42uud4qil67wknywzbxfyxc3b7woewsii54cakq2ould3ldetei"
+    },
+    "app.bsky.embed.external": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.external",
+      "cid": "bafyreigwach36azu4xg3jvcmb6fe53umfln3wkuj5srqsvcjaypa6rw534"
+    },
+    "app.bsky.embed.gallery": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.gallery",
+      "cid": "bafyreia4tixag4sadkirfo63qfma6fz3ifbqanify4e6ce6swkl5lwjnfq"
+    },
+    "app.bsky.embed.images": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.images",
+      "cid": "bafyreifw77mkqkzlvm5csjwutkrnaivsjvlhg2qxdlwwabqpahlyyjrpwi"
+    },
+    "app.bsky.embed.record": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.record",
+      "cid": "bafyreia7yq4c6rqkz32fjf6gj5rcvxsirguducn545s3dvls7qutnn2ali"
+    },
+    "app.bsky.embed.recordWithMedia": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.recordWithMedia",
+      "cid": "bafyreidszvpeqf7copdmowm4ln4eyhahlqxktlvootjjjdmtkwy6s62jya"
+    },
+    "app.bsky.embed.video": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.video",
+      "cid": "bafyreihoxb7lvczityqcv2s5od3rllmkee7tn3m4qg6wn34kd6m45p6v24"
+    },
+    "app.bsky.feed.defs": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.defs",
+      "cid": "bafyreihxsdr5eig2gntbwn5duiskdae6lb7xyrtvump6nzzuz7sspyqv3e"
+    },
+    "app.bsky.feed.getFeedGenerator": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.getFeedGenerator",
+      "cid": "bafyreibdzaan7vboli3ywi7wqzkibc2puukhfpg5rcdgizxlr7fbxx5gcy"
+    },
+    "app.bsky.feed.postgate": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.postgate",
+      "cid": "bafyreiai5efexyluyptv5tbl6kqbqlnneczqzexcqnxmitmulyjfaftgva"
+    },
+    "app.bsky.feed.threadgate": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.threadgate",
+      "cid": "bafyreiht77wd6duduz4yqp62m6dwma5dy7gdihps4g2nd73acfzqlglvdi"
+    },
+    "app.bsky.graph.defs": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.defs",
+      "cid": "bafyreief2f7zpllyicjugbn7faohmnzwujeiytfzj76uckxmrqmtdvechy"
+    },
+    "app.bsky.labeler.defs": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.labeler.defs",
+      "cid": "bafyreicxx5i36v5dbqk5vvfzhnta5gajrvc544mnepux4wksrkid7mw3q4"
+    },
+    "app.bsky.notification.defs": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.notification.defs",
+      "cid": "bafyreifzktxnol5rafjoznauk5j7ub2gsxxm7qjskg3vqmcgn6krrsz55u"
+    },
+    "app.bsky.richtext.facet": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.richtext.facet",
+      "cid": "bafyreidg56eo7zynf6ihz4xb627vwoqf5idnevkmwp7sxc4tijg6xngbu4"
+    },
+    "com.atproto.identity.resolveHandle": {
+      "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.identity.resolveHandle",
+      "cid": "bafyreigckmqtt3jrtzd7tvigjatnz6ajqyafs26h5pwcudwag2anedxnmu"
+    },
+    "com.atproto.label.defs": {
+      "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.label.defs",
+      "cid": "bafyreidp2wpcbzl2qiob2uwoc7lhntojx3tjcr553mmahw2f5cumtm3wpm"
+    },
+    "com.atproto.moderation.defs": {
+      "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.moderation.defs",
+      "cid": "bafyreideawy4rlpgces2oebk5q4kpurbonhb5qtl4pes7dvxsc5osaiksy"
+    },
+    "com.atproto.repo.strongRef": {
+      "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.repo.strongRef",
+      "cid": "bafyreifrkdbnkvfjujntdaeigolnrjj3srrs53tfixjhmacclps72qlov4"
+    },
+    "tools.ozone.report.defs": {
+      "uri": "at://did:plc:33dt5kftu3jq2h5h4jjlqezt/com.atproto.lexicon.schema/tools.ozone.report.defs",
+      "cid": "bafyreic3l2rmh2ugirt3jz372wcvy333m7t2ynlyzj2k54oshijs6lxdfu"
+    }
+  }
+}

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -1,0 +1,883 @@
+{
+  "id": "app.bsky.actor.defs",
+  "defs": {
+    "nux": {
+      "type": "object",
+      "required": ["id", "completed"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "maxLength": 100
+        },
+        "data": {
+          "type": "string",
+          "maxLength": 3000,
+          "description": "Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters.",
+          "maxGraphemes": 300
+        },
+        "completed": {
+          "type": "boolean",
+          "default": false
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The date and time at which the NUX will expire and should be considered completed."
+        }
+      },
+      "description": "A new user experiences (NUX) storage object"
+    },
+    "mutedWord": {
+      "type": "object",
+      "required": ["value", "targets"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "maxLength": 10000,
+          "description": "The muted word itself.",
+          "maxGraphemes": 1000
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.actor.defs#mutedWordTarget",
+            "type": "ref"
+          },
+          "description": "The intended targets of the muted word."
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The date and time at which the muted word will expire and no longer be applied."
+        },
+        "actorTarget": {
+          "type": "string",
+          "default": "all",
+          "description": "Groups of users to apply the muted word to. If undefined, applies to all users.",
+          "knownValues": ["all", "exclude-following"]
+        }
+      },
+      "description": "A word that the account owner has muted."
+    },
+    "savedFeed": {
+      "type": "object",
+      "required": ["id", "type", "value", "pinned"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "knownValues": ["feed", "list", "timeline"]
+        },
+        "value": {
+          "type": "string"
+        },
+        "pinned": {
+          "type": "boolean"
+        }
+      }
+    },
+    "statusView": {
+      "type": "object",
+      "required": ["status", "record"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "embed": {
+          "refs": ["app.bsky.embed.external#view"],
+          "type": "union",
+          "description": "An optional embed associated with the status."
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "record": {
+          "type": "unknown"
+        },
+        "status": {
+          "type": "string",
+          "description": "The status for the account.",
+          "knownValues": ["app.bsky.actor.status#live"]
+        },
+        "isActive": {
+          "type": "boolean",
+          "description": "True if the status is not expired, false if it is expired. Only present if expiration was set."
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The date when this status will expire. The application might choose to no longer return the status after expiration."
+        },
+        "isDisabled": {
+          "type": "boolean",
+          "description": "True if the user's go-live access has been disabled by a moderator, false otherwise."
+        }
+      }
+    },
+    "preferences": {
+      "type": "array",
+      "items": {
+        "refs": [
+          "#adultContentPref",
+          "#contentLabelPref",
+          "#savedFeedsPref",
+          "#savedFeedsPrefV2",
+          "#personalDetailsPref",
+          "#declaredAgePref",
+          "#feedViewPref",
+          "#threadViewPref",
+          "#interestsPref",
+          "#mutedWordsPref",
+          "#hiddenPostsPref",
+          "#bskyAppStatePref",
+          "#labelersPref",
+          "#postInteractionSettingsPref",
+          "#verificationPrefs",
+          "#liveEventPreferences"
+        ],
+        "type": "union"
+      }
+    },
+    "profileView": {
+      "type": "object",
+      "required": ["did", "handle"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        },
+        "debug": {
+          "type": "unknown",
+          "description": "Debug information for internal development"
+        },
+        "avatar": {
+          "type": "string",
+          "format": "uri"
+        },
+        "handle": {
+          "type": "string",
+          "format": "handle"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "status": {
+          "ref": "#statusView",
+          "type": "ref"
+        },
+        "viewer": {
+          "ref": "#viewerState",
+          "type": "ref"
+        },
+        "pronouns": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "associated": {
+          "ref": "#profileAssociated",
+          "type": "ref"
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 2560,
+          "maxGraphemes": 256
+        },
+        "displayName": {
+          "type": "string",
+          "maxLength": 640,
+          "maxGraphemes": 64
+        },
+        "verification": {
+          "ref": "#verificationState",
+          "type": "ref"
+        }
+      }
+    },
+    "viewerState": {
+      "type": "object",
+      "properties": {
+        "muted": {
+          "type": "boolean",
+          "description": "Whether the account is fully muted, directly or via a mutelist. False when the mute is scoped to specific kinds; see mutedOnlyReposts and mutedOnlyQuoteposts."
+        },
+        "blocking": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "blockedBy": {
+          "type": "boolean"
+        },
+        "following": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "followedBy": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "mutedByList": {
+          "ref": "app.bsky.graph.defs#listViewBasic",
+          "type": "ref"
+        },
+        "blockingByList": {
+          "ref": "app.bsky.graph.defs#listViewBasic",
+          "type": "ref"
+        },
+        "knownFollowers": {
+          "ref": "#knownFollowers",
+          "type": "ref",
+          "description": "This property is present only in selected cases, as an optimization."
+        },
+        "mutedOnlyReposts": {
+          "type": "boolean",
+          "description": "Whether the account's reposts are muted. Scoped mutes are exclusive with muted: this can be true while muted is false. If muted is true, this will be false."
+        },
+        "mutedOnlyQuoteposts": {
+          "type": "boolean",
+          "description": "Whether the account's quote posts are muted. Scoped mutes are exclusive with muted: this can be true while muted is false. If muted is true, this will be false."
+        },
+        "activitySubscription": {
+          "ref": "app.bsky.notification.defs#activitySubscription",
+          "type": "ref",
+          "description": "This property is present only in selected cases, as an optimization."
+        }
+      },
+      "description": "Metadata about the requesting account's relationship with the subject account. Only has meaningful content for authed requests."
+    },
+    "feedViewPref": {
+      "type": "object",
+      "required": ["feed"],
+      "properties": {
+        "feed": {
+          "type": "string",
+          "description": "The URI of the feed, or an identifier which describes the feed."
+        },
+        "hideReplies": {
+          "type": "boolean",
+          "description": "Hide replies in the feed."
+        },
+        "hideReposts": {
+          "type": "boolean",
+          "description": "Hide reposts in the feed."
+        },
+        "hideQuotePosts": {
+          "type": "boolean",
+          "description": "Hide quote posts in the feed."
+        },
+        "hideRepliesByLikeCount": {
+          "type": "integer",
+          "description": "Hide replies in the feed if they do not have this number of likes."
+        },
+        "hideRepliesByUnfollowed": {
+          "type": "boolean",
+          "default": true,
+          "description": "Hide replies in the feed if they are not by followed users."
+        }
+      }
+    },
+    "labelersPref": {
+      "type": "object",
+      "required": ["labelers"],
+      "properties": {
+        "labelers": {
+          "type": "array",
+          "items": {
+            "ref": "#labelerPrefItem",
+            "type": "ref"
+          }
+        }
+      }
+    },
+    "interestsPref": {
+      "type": "object",
+      "required": ["tags"],
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 640,
+            "maxGraphemes": 64
+          },
+          "maxLength": 100,
+          "description": "A list of tags which describe the account owner's interests gathered during onboarding."
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The timestamp when the account owner last updated their interests."
+        }
+      }
+    },
+    "knownFollowers": {
+      "type": "object",
+      "required": ["count", "followers"],
+      "properties": {
+        "count": {
+          "type": "integer"
+        },
+        "followers": {
+          "type": "array",
+          "items": {
+            "ref": "#profileViewBasic",
+            "type": "ref"
+          },
+          "maxLength": 5,
+          "minLength": 0
+        }
+      },
+      "description": "The subject's followers whom you also follow"
+    },
+    "mutedWordsPref": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.actor.defs#mutedWord",
+            "type": "ref"
+          },
+          "description": "A list of words the account owner has muted."
+        }
+      }
+    },
+    "savedFeedsPref": {
+      "type": "object",
+      "required": ["pinned", "saved"],
+      "properties": {
+        "saved": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "at-uri"
+          }
+        },
+        "pinned": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "at-uri"
+          }
+        },
+        "timelineIndex": {
+          "type": "integer"
+        }
+      }
+    },
+    "threadViewPref": {
+      "type": "object",
+      "properties": {
+        "sort": {
+          "type": "string",
+          "description": "Sorting mode for threads.",
+          "knownValues": ["oldest", "newest", "most-likes", "random", "hotness"]
+        }
+      }
+    },
+    "declaredAgePref": {
+      "type": "object",
+      "properties": {
+        "isOverAge13": {
+          "type": "boolean",
+          "description": "Indicates if the user has declared that they are over 13 years of age."
+        },
+        "isOverAge16": {
+          "type": "boolean",
+          "description": "Indicates if the user has declared that they are over 16 years of age."
+        },
+        "isOverAge18": {
+          "type": "boolean",
+          "description": "Indicates if the user has declared that they are over 18 years of age."
+        }
+      },
+      "description": "Read-only preference containing value(s) inferred from the user's declared birthdate. Absence of this preference object in the response indicates that the user has not made a declaration."
+    },
+    "hiddenPostsPref": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "at-uri"
+          },
+          "description": "A list of URIs of posts the account owner has hidden."
+        }
+      }
+    },
+    "labelerPrefItem": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        }
+      }
+    },
+    "mutedWordTarget": {
+      "type": "string",
+      "maxLength": 640,
+      "knownValues": ["content", "tag"],
+      "maxGraphemes": 64
+    },
+    "adultContentPref": {
+      "type": "object",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "bskyAppStatePref": {
+      "type": "object",
+      "properties": {
+        "nuxs": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.actor.defs#nux",
+            "type": "ref"
+          },
+          "maxLength": 100,
+          "description": "Storage for NUXs the user has encountered."
+        },
+        "isBetaUser": {
+          "type": "boolean",
+          "description": "Indicates if the user is participating in the beta features program."
+        },
+        "queuedNudges": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "maxLength": 1000,
+          "description": "An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user."
+        },
+        "activeProgressGuide": {
+          "ref": "#bskyAppProgressGuide",
+          "type": "ref"
+        }
+      },
+      "description": "A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this."
+    },
+    "contentLabelPref": {
+      "type": "object",
+      "required": ["label", "visibility"],
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "labelerDid": {
+          "type": "string",
+          "format": "did",
+          "description": "Which labeler does this preference apply to? If undefined, applies globally."
+        },
+        "visibility": {
+          "type": "string",
+          "knownValues": ["ignore", "show", "warn", "hide"]
+        }
+      }
+    },
+    "profileViewBasic": {
+      "type": "object",
+      "required": ["did", "handle"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        },
+        "debug": {
+          "type": "unknown",
+          "description": "Debug information for internal development"
+        },
+        "avatar": {
+          "type": "string",
+          "format": "uri"
+        },
+        "handle": {
+          "type": "string",
+          "format": "handle"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "status": {
+          "ref": "#statusView",
+          "type": "ref"
+        },
+        "viewer": {
+          "ref": "#viewerState",
+          "type": "ref"
+        },
+        "pronouns": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "associated": {
+          "ref": "#profileAssociated",
+          "type": "ref"
+        },
+        "displayName": {
+          "type": "string",
+          "maxLength": 640,
+          "maxGraphemes": 64
+        },
+        "verification": {
+          "ref": "#verificationState",
+          "type": "ref"
+        }
+      }
+    },
+    "savedFeedsPrefV2": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.actor.defs#savedFeed",
+            "type": "ref"
+          }
+        }
+      }
+    },
+    "verificationView": {
+      "type": "object",
+      "required": ["issuer", "uri", "isValid", "createdAt"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "The AT-URI of the verification record."
+        },
+        "issuer": {
+          "type": "string",
+          "format": "did",
+          "description": "The user who issued this verification."
+        },
+        "isValid": {
+          "type": "boolean",
+          "description": "True if the verification passes validation, otherwise false."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp when the verification was created."
+        },
+        "issuerHandle": {
+          "type": "string",
+          "format": "handle",
+          "description": "The handle of the issuer."
+        },
+        "issuerDisplayName": {
+          "type": "string",
+          "description": "The display name of the issuer."
+        }
+      },
+      "description": "An individual verification for an associated subject."
+    },
+    "profileAssociated": {
+      "type": "object",
+      "properties": {
+        "chat": {
+          "ref": "#profileAssociatedChat",
+          "type": "ref"
+        },
+        "germ": {
+          "ref": "#profileAssociatedGerm",
+          "type": "ref"
+        },
+        "lists": {
+          "type": "integer"
+        },
+        "labeler": {
+          "type": "boolean"
+        },
+        "feedgens": {
+          "type": "integer"
+        },
+        "starterPacks": {
+          "type": "integer"
+        },
+        "activitySubscription": {
+          "ref": "#profileAssociatedActivitySubscription",
+          "type": "ref"
+        }
+      }
+    },
+    "verificationPrefs": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "hideBadges": {
+          "type": "boolean",
+          "default": false,
+          "description": "Hide the blue check badges for verified accounts and trusted verifiers."
+        }
+      },
+      "description": "Preferences for how verified accounts appear in the app."
+    },
+    "verificationState": {
+      "type": "object",
+      "required": ["verifications", "verifiedStatus", "trustedVerifierStatus"],
+      "properties": {
+        "verifications": {
+          "type": "array",
+          "items": {
+            "ref": "#verificationView",
+            "type": "ref"
+          },
+          "description": "All verifications issued by trusted verifiers on behalf of this user. Verifications by untrusted verifiers are not included."
+        },
+        "verifiedStatus": {
+          "type": "string",
+          "description": "The user's status as a verified account.",
+          "knownValues": ["valid", "invalid", "none"]
+        },
+        "trustedVerifierStatus": {
+          "type": "string",
+          "description": "The user's status as a trusted verifier.",
+          "knownValues": ["valid", "invalid", "none"]
+        }
+      },
+      "description": "Represents the verification information about the user this object is attached to."
+    },
+    "personalDetailsPref": {
+      "type": "object",
+      "properties": {
+        "birthDate": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The birth date of account owner."
+        }
+      }
+    },
+    "profileViewDetailed": {
+      "type": "object",
+      "required": ["did", "handle"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        },
+        "debug": {
+          "type": "unknown",
+          "description": "Debug information for internal development"
+        },
+        "avatar": {
+          "type": "string",
+          "format": "uri"
+        },
+        "banner": {
+          "type": "string",
+          "format": "uri"
+        },
+        "handle": {
+          "type": "string",
+          "format": "handle"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "status": {
+          "ref": "#statusView",
+          "type": "ref"
+        },
+        "viewer": {
+          "ref": "#viewerState",
+          "type": "ref"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        },
+        "pronouns": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "associated": {
+          "ref": "#profileAssociated",
+          "type": "ref"
+        },
+        "pinnedPost": {
+          "ref": "com.atproto.repo.strongRef",
+          "type": "ref"
+        },
+        "postsCount": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 2560,
+          "maxGraphemes": 256
+        },
+        "displayName": {
+          "type": "string",
+          "maxLength": 640,
+          "maxGraphemes": 64
+        },
+        "followsCount": {
+          "type": "integer"
+        },
+        "verification": {
+          "ref": "#verificationState",
+          "type": "ref"
+        },
+        "followersCount": {
+          "type": "integer"
+        },
+        "joinedViaStarterPack": {
+          "ref": "app.bsky.graph.defs#starterPackViewBasic",
+          "type": "ref"
+        }
+      }
+    },
+    "bskyAppProgressGuide": {
+      "type": "object",
+      "required": ["guide"],
+      "properties": {
+        "guide": {
+          "type": "string",
+          "maxLength": 100
+        }
+      },
+      "description": "If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress."
+    },
+    "liveEventPreferences": {
+      "type": "object",
+      "properties": {
+        "hideAllFeeds": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to hide all feeds from live events."
+        },
+        "hiddenFeedIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of feed IDs that the user has hidden from live events."
+        }
+      },
+      "description": "Preferences for live events."
+    },
+    "profileAssociatedChat": {
+      "type": "object",
+      "required": ["allowIncoming"],
+      "properties": {
+        "allowIncoming": {
+          "type": "string",
+          "knownValues": ["all", "none", "following"]
+        },
+        "allowGroupInvites": {
+          "type": "string",
+          "knownValues": ["all", "none", "following"]
+        }
+      }
+    },
+    "profileAssociatedGerm": {
+      "type": "object",
+      "required": ["showButtonTo", "messageMeUrl"],
+      "properties": {
+        "messageMeUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "showButtonTo": {
+          "type": "string",
+          "knownValues": ["usersIFollow", "everyone"]
+        }
+      }
+    },
+    "postInteractionSettingsPref": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "threadgateAllowRules": {
+          "type": "array",
+          "items": {
+            "refs": [
+              "app.bsky.feed.threadgate#mentionRule",
+              "app.bsky.feed.threadgate#followerRule",
+              "app.bsky.feed.threadgate#followingRule",
+              "app.bsky.feed.threadgate#listRule"
+            ],
+            "type": "union"
+          },
+          "maxLength": 5,
+          "description": "Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply."
+        },
+        "postgateEmbeddingRules": {
+          "type": "array",
+          "items": {
+            "refs": ["app.bsky.feed.postgate#disableRule"],
+            "type": "union"
+          },
+          "maxLength": 5,
+          "description": "Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed."
+        }
+      },
+      "description": "Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly."
+    },
+    "profileAssociatedActivitySubscription": {
+      "type": "object",
+      "required": ["allowSubscriptions"],
+      "properties": {
+        "allowSubscriptions": {
+          "type": "string",
+          "knownValues": ["followers", "mutuals", "none"]
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/actor/getProfile.json
+++ b/lexicons/app/bsky/actor/getProfile.json
@@ -1,0 +1,29 @@
+{
+  "id": "app.bsky.actor.getProfile",
+  "defs": {
+    "main": {
+      "type": "query",
+      "output": {
+        "schema": {
+          "ref": "app.bsky.actor.defs#profileViewDetailed",
+          "type": "ref"
+        },
+        "encoding": "application/json"
+      },
+      "parameters": {
+        "type": "params",
+        "required": ["actor"],
+        "properties": {
+          "actor": {
+            "type": "string",
+            "format": "at-identifier",
+            "description": "Handle or DID of account to fetch profile of."
+          }
+        }
+      },
+      "description": "Get detailed profile view of an actor. Does not require auth, but contains relevant metadata with auth."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/actor/status.json
+++ b/lexicons/app/bsky/actor/status.json
@@ -1,0 +1,41 @@
+{
+  "id": "app.bsky.actor.status",
+  "defs": {
+    "live": {
+      "type": "token",
+      "description": "Advertises an account as currently offering live content."
+    },
+    "main": {
+      "key": "literal:self",
+      "type": "record",
+      "record": {
+        "type": "object",
+        "required": ["status", "createdAt"],
+        "properties": {
+          "embed": {
+            "refs": ["app.bsky.embed.external"],
+            "type": "union",
+            "description": "An optional embed associated with the status."
+          },
+          "status": {
+            "type": "string",
+            "description": "The status for the account.",
+            "knownValues": ["app.bsky.actor.status#live"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "durationMinutes": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The duration of the status in minutes. Applications can choose to impose minimum and maximum limits."
+          }
+        }
+      },
+      "description": "A declaration of a Bluesky account status."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/embed/defs.json
+++ b/lexicons/app/bsky/embed/defs.json
@@ -1,0 +1,22 @@
+{
+  "id": "app.bsky.embed.defs",
+  "defs": {
+    "aspectRatio": {
+      "type": "object",
+      "required": ["width", "height"],
+      "properties": {
+        "width": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "height": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "description": "width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/embed/external.json
+++ b/lexicons/app/bsky/embed/external.json
@@ -1,0 +1,189 @@
+{
+  "id": "app.bsky.embed.external",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["external"],
+      "properties": {
+        "external": {
+          "ref": "#external",
+          "type": "ref"
+        }
+      },
+      "description": "A representation of some externally linked content (eg, a URL and 'card'), embedded in a Bluesky record (eg, a post)."
+    },
+    "view": {
+      "type": "object",
+      "required": ["external"],
+      "properties": {
+        "external": {
+          "ref": "#viewExternal",
+          "type": "ref"
+        }
+      }
+    },
+    "colorRGB": {
+      "type": "object",
+      "required": ["r", "g", "b"],
+      "properties": {
+        "b": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        },
+        "g": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        },
+        "r": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        }
+      },
+      "description": "RGB color definition, inspired by site.standard.theme.color#rgb"
+    },
+    "external": {
+      "type": "object",
+      "required": ["uri", "title", "description"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "thumb": {
+          "type": "blob",
+          "accept": ["image/*"],
+          "maxSize": 1000000
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "associatedRefs": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.repo.strongRef",
+            "type": "ref"
+          },
+          "description": "StrongRefs (uri+cid) of the Atmosphere records that backed this view."
+        }
+      }
+    },
+    "viewExternal": {
+      "type": "object",
+      "required": ["uri", "title", "description"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "thumb": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "source": {
+          "ref": "#viewExternalSource",
+          "type": "ref"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the external content was created, if available. Example: a publication date, for an article."
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the external content was updated, if available."
+        },
+        "description": {
+          "type": "string"
+        },
+        "readingTime": {
+          "type": "integer",
+          "description": "Estimated reading time in minutes, if applicable and available."
+        },
+        "associatedRefs": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.repo.strongRef",
+            "type": "ref"
+          },
+          "description": "StrongRefs (uri+cid) of the Atmosphere records that backed this view."
+        },
+        "associatedProfiles": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.actor.defs#profileViewBasic",
+            "type": "ref"
+          },
+          "description": "Profiles of the owners of the Atmosphere records that backed this view."
+        }
+      }
+    },
+    "viewExternalSource": {
+      "type": "object",
+      "required": ["uri", "title"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI of the source, if available. Example: the https:// URL of a site.standard.publication record."
+        },
+        "icon": {
+          "type": "string",
+          "format": "uri",
+          "description": "Fully-qualified URL where an icon representing the source can be fetched. For example, CDN location provided by the App View."
+        },
+        "theme": {
+          "ref": "#viewExternalSourceTheme",
+          "type": "ref"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "description": "The source of an external embed, such as a standard.site publication."
+    },
+    "viewExternalSourceTheme": {
+      "type": "object",
+      "properties": {
+        "accentRGB": {
+          "ref": "#colorRGB",
+          "type": "ref"
+        },
+        "backgroundRGB": {
+          "ref": "#colorRGB",
+          "type": "ref"
+        },
+        "foregroundRGB": {
+          "ref": "#colorRGB",
+          "type": "ref"
+        },
+        "accentForegroundRGB": {
+          "ref": "#colorRGB",
+          "type": "ref"
+        }
+      },
+      "description": "The theme colors of an external source, such as a site.standard.publication. These colors may be used when rendering an embed from that source."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/embed/gallery.json
+++ b/lexicons/app/bsky/embed/gallery.json
@@ -1,0 +1,80 @@
+{
+  "id": "app.bsky.embed.gallery",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "refs": ["#image"],
+            "type": "union",
+            "description": "The media items in the gallery. Each item may be of a different type, but all types must be supported by the client."
+          },
+          "maxLength": 20,
+          "description": "The schema-level maxLength of 20 is a future-proof ceiling. Clients should currently enforce a soft limit of 10 items in authoring UIs."
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "refs": ["#viewImage"],
+            "type": "union"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": ["image", "alt", "aspectRatio"],
+      "properties": {
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the image, for accessibility."
+        },
+        "image": {
+          "type": "blob",
+          "accept": ["image/*"],
+          "maxSize": 2000000
+        },
+        "aspectRatio": {
+          "ref": "app.bsky.embed.defs#aspectRatio",
+          "type": "ref"
+        }
+      }
+    },
+    "viewImage": {
+      "type": "object",
+      "required": ["thumbnail", "fullsize", "alt", "aspectRatio"],
+      "properties": {
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the image, for accessibility."
+        },
+        "fullsize": {
+          "type": "string",
+          "format": "uri",
+          "description": "Fully-qualified URL where a large version of the image can be fetched. May or may not be the exact original blob. For example, CDN location provided by the App View."
+        },
+        "thumbnail": {
+          "type": "string",
+          "format": "uri",
+          "description": "Fully-qualified URL where a thumbnail of the image can be fetched. For example, CDN location provided by the App View."
+        },
+        "aspectRatio": {
+          "ref": "app.bsky.embed.defs#aspectRatio",
+          "type": "ref"
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
+  "description": "An assortment of media embedded in a Bluesky record (eg, a post)."
+}

--- a/lexicons/app/bsky/embed/images.json
+++ b/lexicons/app/bsky/embed/images.json
@@ -1,0 +1,80 @@
+{
+  "id": "app.bsky.embed.images",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["images"],
+      "properties": {
+        "images": {
+          "type": "array",
+          "items": {
+            "ref": "#image",
+            "type": "ref"
+          },
+          "maxLength": 4
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["images"],
+      "properties": {
+        "images": {
+          "type": "array",
+          "items": {
+            "ref": "#viewImage",
+            "type": "ref"
+          },
+          "maxLength": 4
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": ["image", "alt"],
+      "properties": {
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the image, for accessibility."
+        },
+        "image": {
+          "type": "blob",
+          "accept": ["image/*"],
+          "maxSize": 2000000,
+          "description": "The raw image file. May be up to 2 MB, formerly limited to 1 MB."
+        },
+        "aspectRatio": {
+          "ref": "app.bsky.embed.defs#aspectRatio",
+          "type": "ref"
+        }
+      }
+    },
+    "viewImage": {
+      "type": "object",
+      "required": ["thumb", "fullsize", "alt"],
+      "properties": {
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the image, for accessibility."
+        },
+        "thumb": {
+          "type": "string",
+          "format": "uri",
+          "description": "Fully-qualified URL where a thumbnail of the image can be fetched. For example, CDN location provided by the App View."
+        },
+        "fullsize": {
+          "type": "string",
+          "format": "uri",
+          "description": "Fully-qualified URL where a large version of the image can be fetched. May or may not be the exact original blob. For example, CDN location provided by the App View."
+        },
+        "aspectRatio": {
+          "ref": "app.bsky.embed.defs#aspectRatio",
+          "type": "ref"
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
+  "description": "A set of images embedded in a Bluesky record (eg, a post)."
+}

--- a/lexicons/app/bsky/embed/record.json
+++ b/lexicons/app/bsky/embed/record.json
@@ -1,0 +1,142 @@
+{
+  "id": "app.bsky.embed.record",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["record"],
+      "properties": {
+        "record": {
+          "ref": "com.atproto.repo.strongRef",
+          "type": "ref"
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["record"],
+      "properties": {
+        "record": {
+          "refs": [
+            "#viewRecord",
+            "#viewNotFound",
+            "#viewBlocked",
+            "#viewDetached",
+            "app.bsky.feed.defs#generatorView",
+            "app.bsky.graph.defs#listView",
+            "app.bsky.labeler.defs#labelerView",
+            "app.bsky.graph.defs#starterPackViewBasic"
+          ],
+          "type": "union"
+        }
+      }
+    },
+    "viewRecord": {
+      "type": "object",
+      "required": ["uri", "cid", "author", "value", "indexedAt"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "value": {
+          "type": "unknown",
+          "description": "The record data itself."
+        },
+        "author": {
+          "ref": "app.bsky.actor.defs#profileViewBasic",
+          "type": "ref"
+        },
+        "embeds": {
+          "type": "array",
+          "items": {
+            "refs": [
+              "app.bsky.embed.images#view",
+              "app.bsky.embed.video#view",
+              "app.bsky.embed.gallery#view",
+              "app.bsky.embed.external#view",
+              "app.bsky.embed.record#view",
+              "app.bsky.embed.recordWithMedia#view"
+            ],
+            "type": "union"
+          }
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "likeCount": {
+          "type": "integer"
+        },
+        "quoteCount": {
+          "type": "integer"
+        },
+        "replyCount": {
+          "type": "integer"
+        },
+        "repostCount": {
+          "type": "integer"
+        }
+      }
+    },
+    "viewBlocked": {
+      "type": "object",
+      "required": ["uri", "blocked", "author"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "author": {
+          "ref": "app.bsky.feed.defs#blockedAuthor",
+          "type": "ref"
+        },
+        "blocked": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
+    "viewDetached": {
+      "type": "object",
+      "required": ["uri", "detached"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "detached": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
+    "viewNotFound": {
+      "type": "object",
+      "required": ["uri", "notFound"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "notFound": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
+  "description": "A representation of a record embedded in a Bluesky record (eg, a post). For example, a quote-post, or sharing a feed generator record."
+}

--- a/lexicons/app/bsky/embed/recordWithMedia.json
+++ b/lexicons/app/bsky/embed/recordWithMedia.json
@@ -1,0 +1,46 @@
+{
+  "id": "app.bsky.embed.recordWithMedia",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["record", "media"],
+      "properties": {
+        "media": {
+          "refs": [
+            "app.bsky.embed.images",
+            "app.bsky.embed.video",
+            "app.bsky.embed.gallery",
+            "app.bsky.embed.external"
+          ],
+          "type": "union"
+        },
+        "record": {
+          "ref": "app.bsky.embed.record",
+          "type": "ref"
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["record", "media"],
+      "properties": {
+        "media": {
+          "refs": [
+            "app.bsky.embed.images#view",
+            "app.bsky.embed.video#view",
+            "app.bsky.embed.gallery#view",
+            "app.bsky.embed.external#view"
+          ],
+          "type": "union"
+        },
+        "record": {
+          "ref": "app.bsky.embed.record#view",
+          "type": "ref"
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
+  "description": "A representation of a record embedded in a Bluesky record (eg, a post), alongside other compatible embeds. For example, a quote post and image, or a quote post and external URL card."
+}

--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -1,0 +1,86 @@
+{
+  "id": "app.bsky.embed.video",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["video"],
+      "properties": {
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the video, for accessibility."
+        },
+        "video": {
+          "type": "blob",
+          "accept": ["video/mp4"],
+          "maxSize": 300000000,
+          "description": "The mp4 video file. May be up to 300mb, formerly limited to 100mb."
+        },
+        "captions": {
+          "type": "array",
+          "items": {
+            "ref": "#caption",
+            "type": "ref"
+          },
+          "maxLength": 20
+        },
+        "aspectRatio": {
+          "ref": "app.bsky.embed.defs#aspectRatio",
+          "type": "ref"
+        },
+        "presentation": {
+          "type": "string",
+          "description": "A hint to the client about how to present the video.",
+          "knownValues": ["default", "gif"]
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["cid", "playlist"],
+      "properties": {
+        "alt": {
+          "type": "string"
+        },
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "playlist": {
+          "type": "string",
+          "format": "uri"
+        },
+        "thumbnail": {
+          "type": "string",
+          "format": "uri"
+        },
+        "aspectRatio": {
+          "ref": "app.bsky.embed.defs#aspectRatio",
+          "type": "ref"
+        },
+        "presentation": {
+          "type": "string",
+          "description": "A hint to the client about how to present the video.",
+          "knownValues": ["default", "gif"]
+        }
+      }
+    },
+    "caption": {
+      "type": "object",
+      "required": ["lang", "file"],
+      "properties": {
+        "file": {
+          "type": "blob",
+          "accept": ["text/vtt"],
+          "maxSize": 20000
+        },
+        "lang": {
+          "type": "string",
+          "format": "language"
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
+  "description": "A video embedded in a Bluesky record (eg, a post)."
+}

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -1,0 +1,511 @@
+{
+  "id": "app.bsky.feed.defs",
+  "defs": {
+    "postView": {
+      "type": "object",
+      "required": ["uri", "cid", "author", "record", "indexedAt"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "debug": {
+          "type": "unknown",
+          "description": "Debug information for internal development"
+        },
+        "embed": {
+          "refs": [
+            "app.bsky.embed.images#view",
+            "app.bsky.embed.video#view",
+            "app.bsky.embed.gallery#view",
+            "app.bsky.embed.external#view",
+            "app.bsky.embed.record#view",
+            "app.bsky.embed.recordWithMedia#view"
+          ],
+          "type": "union"
+        },
+        "author": {
+          "ref": "app.bsky.actor.defs#profileViewBasic",
+          "type": "ref"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "record": {
+          "type": "unknown"
+        },
+        "viewer": {
+          "ref": "#viewerState",
+          "type": "ref"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "likeCount": {
+          "type": "integer"
+        },
+        "quoteCount": {
+          "type": "integer"
+        },
+        "replyCount": {
+          "type": "integer"
+        },
+        "threadgate": {
+          "ref": "#threadgateView",
+          "type": "ref"
+        },
+        "repostCount": {
+          "type": "integer"
+        },
+        "bookmarkCount": {
+          "type": "integer"
+        }
+      }
+    },
+    "replyRef": {
+      "type": "object",
+      "required": ["root", "parent"],
+      "properties": {
+        "root": {
+          "refs": ["#postView", "#notFoundPost", "#blockedPost"],
+          "type": "union"
+        },
+        "parent": {
+          "refs": ["#postView", "#notFoundPost", "#blockedPost"],
+          "type": "union"
+        },
+        "grandparentAuthor": {
+          "ref": "app.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "When parent is a reply to another post, this is the author of that post."
+        }
+      }
+    },
+    "reasonPin": {
+      "type": "object",
+      "properties": {}
+    },
+    "blockedPost": {
+      "type": "object",
+      "required": ["uri", "blocked", "author"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "author": {
+          "ref": "#blockedAuthor",
+          "type": "ref"
+        },
+        "blocked": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
+    "interaction": {
+      "type": "object",
+      "properties": {
+        "item": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "event": {
+          "type": "string",
+          "knownValues": [
+            "app.bsky.feed.defs#requestLess",
+            "app.bsky.feed.defs#requestMore",
+            "app.bsky.feed.defs#clickthroughItem",
+            "app.bsky.feed.defs#clickthroughAuthor",
+            "app.bsky.feed.defs#clickthroughReposter",
+            "app.bsky.feed.defs#clickthroughEmbed",
+            "app.bsky.feed.defs#interactionSeen",
+            "app.bsky.feed.defs#interactionLike",
+            "app.bsky.feed.defs#interactionRepost",
+            "app.bsky.feed.defs#interactionReply",
+            "app.bsky.feed.defs#interactionQuote",
+            "app.bsky.feed.defs#interactionShare"
+          ]
+        },
+        "reqId": {
+          "type": "string",
+          "maxLength": 100,
+          "description": "Unique identifier per request that may be passed back alongside interactions."
+        },
+        "feedContext": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton."
+        }
+      }
+    },
+    "knownLikers": {
+      "type": "object",
+      "required": ["count", "actors"],
+      "properties": {
+        "count": {
+          "type": "integer"
+        },
+        "actors": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.actor.defs#profileViewBasic",
+            "type": "ref"
+          },
+          "maxLength": 5,
+          "minLength": 0
+        }
+      },
+      "description": "The post's likers whom you also follow"
+    },
+    "requestLess": {
+      "type": "token",
+      "description": "Request that less content like the given feed item be shown in the feed"
+    },
+    "requestMore": {
+      "type": "token",
+      "description": "Request that more content like the given feed item be shown in the feed"
+    },
+    "viewerState": {
+      "type": "object",
+      "properties": {
+        "like": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "pinned": {
+          "type": "boolean"
+        },
+        "repost": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "bookmarked": {
+          "type": "boolean"
+        },
+        "knownLikers": {
+          "ref": "#knownLikers",
+          "type": "ref",
+          "description": "This property is present only in selected cases, as an optimization."
+        },
+        "threadMuted": {
+          "type": "boolean"
+        },
+        "replyDisabled": {
+          "type": "boolean"
+        },
+        "embeddingDisabled": {
+          "type": "boolean"
+        }
+      },
+      "description": "Metadata about the requesting account's relationship with the subject content. Only has meaningful content for authed requests."
+    },
+    "feedViewPost": {
+      "type": "object",
+      "required": ["post"],
+      "properties": {
+        "post": {
+          "ref": "#postView",
+          "type": "ref"
+        },
+        "reply": {
+          "ref": "#replyRef",
+          "type": "ref"
+        },
+        "reqId": {
+          "type": "string",
+          "maxLength": 100,
+          "description": "Unique identifier per request that may be passed back alongside interactions."
+        },
+        "reason": {
+          "refs": ["#reasonRepost", "#reasonPin"],
+          "type": "union"
+        },
+        "feedContext": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Context provided by feed generator that may be passed back alongside interactions."
+        }
+      }
+    },
+    "notFoundPost": {
+      "type": "object",
+      "required": ["uri", "notFound"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "notFound": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
+    "reasonRepost": {
+      "type": "object",
+      "required": ["by", "indexedAt"],
+      "properties": {
+        "by": {
+          "ref": "app.bsky.actor.defs#profileViewBasic",
+          "type": "ref"
+        },
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    },
+    "blockedAuthor": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        },
+        "viewer": {
+          "ref": "app.bsky.actor.defs#viewerState",
+          "type": "ref"
+        }
+      }
+    },
+    "generatorView": {
+      "type": "object",
+      "required": ["uri", "cid", "did", "creator", "displayName", "indexedAt"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "did": {
+          "type": "string",
+          "format": "did"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "avatar": {
+          "type": "string",
+          "format": "uri"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "viewer": {
+          "ref": "#generatorViewerState",
+          "type": "ref"
+        },
+        "creator": {
+          "ref": "app.bsky.actor.defs#profileView",
+          "type": "ref"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "likeCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "contentMode": {
+          "type": "string",
+          "knownValues": [
+            "app.bsky.feed.defs#contentModeUnspecified",
+            "app.bsky.feed.defs#contentModeVideo"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 3000,
+          "maxGraphemes": 300
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "descriptionFacets": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.richtext.facet",
+            "type": "ref"
+          }
+        },
+        "acceptsInteractions": {
+          "type": "boolean"
+        }
+      }
+    },
+    "threadContext": {
+      "type": "object",
+      "properties": {
+        "rootAuthorLike": {
+          "type": "string",
+          "format": "at-uri"
+        }
+      },
+      "description": "Metadata about this post within the context of the thread it is in."
+    },
+    "threadViewPost": {
+      "type": "object",
+      "required": ["post"],
+      "properties": {
+        "post": {
+          "ref": "#postView",
+          "type": "ref"
+        },
+        "parent": {
+          "refs": ["#threadViewPost", "#notFoundPost", "#blockedPost"],
+          "type": "union"
+        },
+        "replies": {
+          "type": "array",
+          "items": {
+            "refs": ["#threadViewPost", "#notFoundPost", "#blockedPost"],
+            "type": "union"
+          }
+        },
+        "threadContext": {
+          "ref": "#threadContext",
+          "type": "ref"
+        }
+      }
+    },
+    "threadgateView": {
+      "type": "object",
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "lists": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.graph.defs#listViewBasic",
+            "type": "ref"
+          }
+        },
+        "record": {
+          "type": "unknown"
+        }
+      }
+    },
+    "interactionLike": {
+      "type": "token",
+      "description": "User liked the feed item"
+    },
+    "interactionSeen": {
+      "type": "token",
+      "description": "Feed item was seen by user"
+    },
+    "clickthroughItem": {
+      "type": "token",
+      "description": "User clicked through to the feed item"
+    },
+    "contentModeVideo": {
+      "type": "token",
+      "description": "Declares the feed generator returns posts containing app.bsky.embed.video embeds."
+    },
+    "interactionQuote": {
+      "type": "token",
+      "description": "User quoted the feed item"
+    },
+    "interactionReply": {
+      "type": "token",
+      "description": "User replied to the feed item"
+    },
+    "interactionShare": {
+      "type": "token",
+      "description": "User shared the feed item"
+    },
+    "skeletonFeedPost": {
+      "type": "object",
+      "required": ["post"],
+      "properties": {
+        "post": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "reason": {
+          "refs": ["#skeletonReasonRepost", "#skeletonReasonPin"],
+          "type": "union"
+        },
+        "feedContext": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Context that will be passed through to client and may be passed to feed generator back alongside interactions."
+        }
+      }
+    },
+    "clickthroughEmbed": {
+      "type": "token",
+      "description": "User clicked through to the embedded content of the feed item"
+    },
+    "interactionRepost": {
+      "type": "token",
+      "description": "User reposted the feed item"
+    },
+    "skeletonReasonPin": {
+      "type": "object",
+      "properties": {}
+    },
+    "clickthroughAuthor": {
+      "type": "token",
+      "description": "User clicked through to the author of the feed item"
+    },
+    "clickthroughReposter": {
+      "type": "token",
+      "description": "User clicked through to the reposter of the feed item"
+    },
+    "generatorViewerState": {
+      "type": "object",
+      "properties": {
+        "like": {
+          "type": "string",
+          "format": "at-uri"
+        }
+      }
+    },
+    "skeletonReasonRepost": {
+      "type": "object",
+      "required": ["repost"],
+      "properties": {
+        "repost": {
+          "type": "string",
+          "format": "at-uri"
+        }
+      }
+    },
+    "contentModeUnspecified": {
+      "type": "token",
+      "description": "Declares the feed generator returns any types of posts."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/feed/getFeedGenerator.json
+++ b/lexicons/app/bsky/feed/getFeedGenerator.json
@@ -1,0 +1,43 @@
+{
+  "id": "app.bsky.feed.getFeedGenerator",
+  "defs": {
+    "main": {
+      "type": "query",
+      "output": {
+        "schema": {
+          "type": "object",
+          "required": ["view", "isOnline", "isValid"],
+          "properties": {
+            "view": {
+              "ref": "app.bsky.feed.defs#generatorView",
+              "type": "ref"
+            },
+            "isValid": {
+              "type": "boolean",
+              "description": "Indicates whether the feed generator service is compatible with the record declaration."
+            },
+            "isOnline": {
+              "type": "boolean",
+              "description": "Indicates whether the feed generator service has been online recently, or else seems to be inactive."
+            }
+          }
+        },
+        "encoding": "application/json"
+      },
+      "parameters": {
+        "type": "params",
+        "required": ["feed"],
+        "properties": {
+          "feed": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI of the feed generator record."
+          }
+        }
+      },
+      "description": "Get information about a feed generator. Implemented by AppView."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/feed/postgate.json
+++ b/lexicons/app/bsky/feed/postgate.json
@@ -1,0 +1,50 @@
+{
+  "id": "app.bsky.feed.postgate",
+  "defs": {
+    "main": {
+      "key": "tid",
+      "type": "record",
+      "record": {
+        "type": "object",
+        "required": ["post", "createdAt"],
+        "properties": {
+          "post": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Reference (AT-URI) to the post record."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "embeddingRules": {
+            "type": "array",
+            "items": {
+              "refs": ["#disableRule"],
+              "type": "union"
+            },
+            "maxLength": 5,
+            "description": "List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed."
+          },
+          "detachedEmbeddingUris": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "at-uri"
+            },
+            "maxLength": 50,
+            "description": "List of AT-URIs embedding this post that the author has detached from."
+          }
+        }
+      },
+      "description": "Record defining interaction rules for a post. The record key (rkey) of the postgate record must match the record key of the post, and that record must be in the same repository."
+    },
+    "disableRule": {
+      "type": "object",
+      "properties": {},
+      "description": "Disables embedding of this post."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/feed/threadgate.json
+++ b/lexicons/app/bsky/feed/threadgate.json
@@ -1,0 +1,76 @@
+{
+  "id": "app.bsky.feed.threadgate",
+  "defs": {
+    "main": {
+      "key": "tid",
+      "type": "record",
+      "record": {
+        "type": "object",
+        "required": ["post", "createdAt"],
+        "properties": {
+          "post": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Reference (AT-URI) to the post record."
+          },
+          "allow": {
+            "type": "array",
+            "items": {
+              "refs": [
+                "#mentionRule",
+                "#followerRule",
+                "#followingRule",
+                "#listRule"
+              ],
+              "type": "union"
+            },
+            "maxLength": 5,
+            "description": "List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "hiddenReplies": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "at-uri"
+            },
+            "maxLength": 300,
+            "description": "List of hidden reply URIs."
+          }
+        }
+      },
+      "description": "Record defining interaction gating rules for a thread (aka, reply controls). The record key (rkey) of the threadgate record must match the record key of the thread's root post, and that record must be in the same repository."
+    },
+    "listRule": {
+      "type": "object",
+      "required": ["list"],
+      "properties": {
+        "list": {
+          "type": "string",
+          "format": "at-uri"
+        }
+      },
+      "description": "Allow replies from actors on a list."
+    },
+    "mentionRule": {
+      "type": "object",
+      "properties": {},
+      "description": "Allow replies from actors mentioned in your post."
+    },
+    "followerRule": {
+      "type": "object",
+      "properties": {},
+      "description": "Allow replies from actors who follow you."
+    },
+    "followingRule": {
+      "type": "object",
+      "properties": {},
+      "description": "Allow replies from actors you follow."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/graph/defs.json
+++ b/lexicons/app/bsky/graph/defs.json
@@ -1,0 +1,331 @@
+{
+  "id": "app.bsky.graph.defs",
+  "defs": {
+    "modlist": {
+      "type": "token",
+      "description": "A list of actors to apply an aggregate moderation action (mute/block) on."
+    },
+    "listView": {
+      "type": "object",
+      "required": ["uri", "cid", "creator", "name", "purpose", "indexedAt"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 64,
+          "minLength": 1
+        },
+        "avatar": {
+          "type": "string",
+          "format": "uri"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "viewer": {
+          "ref": "#listViewerState",
+          "type": "ref"
+        },
+        "creator": {
+          "ref": "app.bsky.actor.defs#profileView",
+          "type": "ref"
+        },
+        "purpose": {
+          "ref": "#listPurpose",
+          "type": "ref"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 3000,
+          "maxGraphemes": 300
+        },
+        "listItemCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "descriptionFacets": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.richtext.facet",
+            "type": "ref"
+          }
+        }
+      }
+    },
+    "curatelist": {
+      "type": "token",
+      "description": "A list of actors used for curation purposes such as list feeds or interaction gating."
+    },
+    "listPurpose": {
+      "type": "string",
+      "knownValues": [
+        "app.bsky.graph.defs#modlist",
+        "app.bsky.graph.defs#curatelist",
+        "app.bsky.graph.defs#referencelist"
+      ]
+    },
+    "listItemView": {
+      "type": "object",
+      "required": ["uri", "subject"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "subject": {
+          "ref": "app.bsky.actor.defs#profileView",
+          "type": "ref"
+        },
+        "subjectOptedOut": {
+          "type": "boolean",
+          "const": true,
+          "description": "Set to true when the subject has opted out of appearing in the reference list. Only set when the viewer owns the list."
+        }
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        },
+        "blocking": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor blocks this DID, this is the AT-URI of the block record"
+        },
+        "blockedBy": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor is blocked by this DID, contains the AT-URI of the block record"
+        },
+        "following": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor follows this DID, this is the AT-URI of the follow record"
+        },
+        "followedBy": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor is followed by this DID, contains the AT-URI of the follow record"
+        },
+        "blockedByList": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor is blocked by this DID via a block list, contains the AT-URI of the listblock record"
+        },
+        "blockingByList": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor blocks this DID via a block list, this is the AT-URI of the listblock record"
+        }
+      },
+      "description": "lists the bi-directional graph relationships between one actor (not indicated in the object), and the target actors (the DID included in the object)"
+    },
+    "listViewBasic": {
+      "type": "object",
+      "required": ["uri", "cid", "name", "purpose"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 64,
+          "minLength": 1
+        },
+        "avatar": {
+          "type": "string",
+          "format": "uri"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "viewer": {
+          "ref": "#listViewerState",
+          "type": "ref"
+        },
+        "purpose": {
+          "ref": "#listPurpose",
+          "type": "ref"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "listItemCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "notFoundActor": {
+      "type": "object",
+      "required": ["actor", "notFound"],
+      "properties": {
+        "actor": {
+          "type": "string",
+          "format": "at-identifier"
+        },
+        "notFound": {
+          "type": "boolean",
+          "const": true
+        }
+      },
+      "description": "indicates that a handle or DID could not be resolved"
+    },
+    "referencelist": {
+      "type": "token",
+      "description": "A list of actors used for only for reference purposes such as within a starter pack."
+    },
+    "listViewerState": {
+      "type": "object",
+      "properties": {
+        "muted": {
+          "type": "boolean"
+        },
+        "blocked": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "referenceListOptOut": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "The authenticated viewer's app.bsky.graph.referencelistoptout record URI for this reference list. Only set for reference lists. A client can delete this record to undo the opt-out."
+        }
+      }
+    },
+    "starterPackView": {
+      "type": "object",
+      "required": ["uri", "cid", "record", "creator", "indexedAt"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "list": {
+          "ref": "#listViewBasic",
+          "type": "ref"
+        },
+        "feeds": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.feed.defs#generatorView",
+            "type": "ref"
+          },
+          "maxLength": 3
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "record": {
+          "type": "unknown"
+        },
+        "creator": {
+          "ref": "app.bsky.actor.defs#profileViewBasic",
+          "type": "ref"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "joinedWeekCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "listItemsSample": {
+          "type": "array",
+          "items": {
+            "ref": "#listItemView",
+            "type": "ref"
+          },
+          "maxLength": 12
+        },
+        "joinedAllTimeCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "starterPackViewBasic": {
+      "type": "object",
+      "required": ["uri", "cid", "record", "creator", "indexedAt"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "record": {
+          "type": "unknown"
+        },
+        "creator": {
+          "ref": "app.bsky.actor.defs#profileViewBasic",
+          "type": "ref"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "listItemCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "joinedWeekCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "joinedAllTimeCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/labeler/defs.json
+++ b/lexicons/app/bsky/labeler/defs.json
@@ -1,0 +1,140 @@
+{
+  "id": "app.bsky.labeler.defs",
+  "defs": {
+    "labelerView": {
+      "type": "object",
+      "required": ["uri", "cid", "creator", "indexedAt"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "viewer": {
+          "ref": "#labelerViewerState",
+          "type": "ref"
+        },
+        "creator": {
+          "ref": "app.bsky.actor.defs#profileView",
+          "type": "ref"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "likeCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "labelerPolicies": {
+      "type": "object",
+      "required": ["labelValues"],
+      "properties": {
+        "labelValues": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#labelValue",
+            "type": "ref"
+          },
+          "description": "The label values which this labeler publishes. May include global or custom labels."
+        },
+        "labelValueDefinitions": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#labelValueDefinition",
+            "type": "ref"
+          },
+          "description": "Label values created by this labeler and scoped exclusively to it. Labels defined here will override global label definitions for this labeler."
+        }
+      }
+    },
+    "labelerViewerState": {
+      "type": "object",
+      "properties": {
+        "like": {
+          "type": "string",
+          "format": "at-uri"
+        }
+      }
+    },
+    "labelerViewDetailed": {
+      "type": "object",
+      "required": ["uri", "cid", "creator", "policies", "indexedAt"],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.label.defs#label",
+            "type": "ref"
+          }
+        },
+        "viewer": {
+          "ref": "#labelerViewerState",
+          "type": "ref"
+        },
+        "creator": {
+          "ref": "app.bsky.actor.defs#profileView",
+          "type": "ref"
+        },
+        "policies": {
+          "ref": "app.bsky.labeler.defs#labelerPolicies",
+          "type": "ref"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "likeCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "reasonTypes": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.moderation.defs#reasonType",
+            "type": "ref"
+          },
+          "description": "The set of report reason 'codes' which are in-scope for this service to review and action. These usually align to policy categories. If not defined (distinct from empty array), all reason types are allowed."
+        },
+        "subjectTypes": {
+          "type": "array",
+          "items": {
+            "ref": "com.atproto.moderation.defs#subjectType",
+            "type": "ref"
+          },
+          "description": "The set of subject types (account, record, etc) this service accepts reports on."
+        },
+        "subjectCollections": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "nsid"
+          },
+          "description": "Set of record types (collection NSIDs) which can be reported to this service. If not defined (distinct from empty array), default is any record type."
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/notification/defs.json
+++ b/lexicons/app/bsky/notification/defs.json
@@ -1,0 +1,153 @@
+{
+  "id": "app.bsky.notification.defs",
+  "defs": {
+    "preference": {
+      "type": "object",
+      "required": ["list", "push"],
+      "properties": {
+        "list": {
+          "type": "boolean"
+        },
+        "push": {
+          "type": "boolean"
+        }
+      }
+    },
+    "preferences": {
+      "type": "object",
+      "required": [
+        "chat",
+        "follow",
+        "like",
+        "likeViaRepost",
+        "mention",
+        "quote",
+        "reply",
+        "repost",
+        "repostViaRepost",
+        "starterpackJoined",
+        "subscribedPost",
+        "unverified",
+        "verified"
+      ],
+      "properties": {
+        "chat": {
+          "ref": "#chatPreference",
+          "type": "ref",
+          "description": "Deprecated: use chat.bsky.notification preferences instead. This will only return a default value."
+        },
+        "like": {
+          "ref": "#filterablePreference",
+          "type": "ref"
+        },
+        "quote": {
+          "ref": "#filterablePreference",
+          "type": "ref"
+        },
+        "reply": {
+          "ref": "#filterablePreference",
+          "type": "ref"
+        },
+        "follow": {
+          "ref": "#filterablePreference",
+          "type": "ref"
+        },
+        "repost": {
+          "ref": "#filterablePreference",
+          "type": "ref"
+        },
+        "mention": {
+          "ref": "#filterablePreference",
+          "type": "ref"
+        },
+        "verified": {
+          "ref": "#preference",
+          "type": "ref"
+        },
+        "unverified": {
+          "ref": "#preference",
+          "type": "ref"
+        },
+        "likeViaRepost": {
+          "ref": "#filterablePreference",
+          "type": "ref"
+        },
+        "subscribedPost": {
+          "ref": "#preference",
+          "type": "ref"
+        },
+        "repostViaRepost": {
+          "ref": "#filterablePreference",
+          "type": "ref"
+        },
+        "starterpackJoined": {
+          "ref": "#preference",
+          "type": "ref"
+        }
+      }
+    },
+    "recordDeleted": {
+      "type": "object",
+      "properties": {}
+    },
+    "chatPreference": {
+      "type": "object",
+      "required": ["include", "push"],
+      "properties": {
+        "push": {
+          "type": "boolean"
+        },
+        "include": {
+          "type": "string",
+          "knownValues": ["all", "accepted"]
+        }
+      },
+      "description": "Deprecated: use chat.bsky.notification preferences instead. This will only return a default value."
+    },
+    "activitySubscription": {
+      "type": "object",
+      "required": ["post", "reply"],
+      "properties": {
+        "post": {
+          "type": "boolean"
+        },
+        "reply": {
+          "type": "boolean"
+        }
+      }
+    },
+    "filterablePreference": {
+      "type": "object",
+      "required": ["include", "list", "push"],
+      "properties": {
+        "list": {
+          "type": "boolean"
+        },
+        "push": {
+          "type": "boolean"
+        },
+        "include": {
+          "type": "string",
+          "knownValues": ["all", "follows"]
+        }
+      }
+    },
+    "subjectActivitySubscription": {
+      "type": "object",
+      "required": ["subject", "activitySubscription"],
+      "properties": {
+        "subject": {
+          "type": "string",
+          "format": "did"
+        },
+        "activitySubscription": {
+          "ref": "#activitySubscription",
+          "type": "ref"
+        }
+      },
+      "description": "Object used to store activity subscription data in stash."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/app/bsky/richtext/facet.json
+++ b/lexicons/app/bsky/richtext/facet.json
@@ -1,0 +1,74 @@
+{
+  "id": "app.bsky.richtext.facet",
+  "defs": {
+    "tag": {
+      "type": "object",
+      "required": ["tag"],
+      "properties": {
+        "tag": {
+          "type": "string",
+          "maxLength": 640,
+          "maxGraphemes": 64
+        }
+      },
+      "description": "Facet feature for a hashtag. The text usually includes a '#' prefix, but the facet reference should not (except in the case of 'double hash tags')."
+    },
+    "link": {
+      "type": "object",
+      "required": ["uri"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "description": "Facet feature for a URL. The text URL may have been simplified or truncated, but the facet reference should be a complete URL."
+    },
+    "main": {
+      "type": "object",
+      "required": ["index", "features"],
+      "properties": {
+        "index": {
+          "ref": "#byteSlice",
+          "type": "ref"
+        },
+        "features": {
+          "type": "array",
+          "items": {
+            "refs": ["#mention", "#link", "#tag"],
+            "type": "union"
+          }
+        }
+      },
+      "description": "Annotation of a sub-string within rich text."
+    },
+    "mention": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        }
+      },
+      "description": "Facet feature for mention of another account. The text is usually a handle, including a '@' prefix, but the facet reference is a DID."
+    },
+    "byteSlice": {
+      "type": "object",
+      "required": ["byteStart", "byteEnd"],
+      "properties": {
+        "byteEnd": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "byteStart": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "description": "Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/com/atproto/identity/resolveHandle.json
+++ b/lexicons/com/atproto/identity/resolveHandle.json
@@ -1,0 +1,45 @@
+{
+  "id": "com.atproto.identity.resolveHandle",
+  "defs": {
+    "main": {
+      "type": "query",
+      "errors": [
+        {
+          "name": "HandleNotFound",
+          "description": "The resolution process confirmed that the handle does not resolve to any DID."
+        }
+      ],
+      "output": {
+        "schema": {
+          "type": "object",
+          "required": [
+            "did"
+          ],
+          "properties": {
+            "did": {
+              "type": "string",
+              "format": "did"
+            }
+          }
+        },
+        "encoding": "application/json"
+      },
+      "parameters": {
+        "type": "params",
+        "required": [
+          "handle"
+        ],
+        "properties": {
+          "handle": {
+            "type": "string",
+            "format": "handle",
+            "description": "The handle to resolve."
+          }
+        }
+      },
+      "description": "Resolves an atproto handle (hostname) to a DID. Does not necessarily bi-directionally verify against the the DID document."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/com/atproto/label/defs.json
+++ b/lexicons/com/atproto/label/defs.json
@@ -1,0 +1,190 @@
+{
+  "id": "com.atproto.label.defs",
+  "defs": {
+    "label": {
+      "type": "object",
+      "required": [
+        "src",
+        "uri",
+        "val",
+        "cts"
+      ],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid",
+          "description": "Optionally, CID specifying the specific version of 'uri' resource this label applies to."
+        },
+        "cts": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp when this label was created."
+        },
+        "exp": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp at which this label expires (no longer applies)."
+        },
+        "neg": {
+          "type": "boolean",
+          "description": "If true, this is a negation label, overwriting a previous label."
+        },
+        "sig": {
+          "type": "bytes",
+          "description": "Signature of dag-cbor encoded label."
+        },
+        "src": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the actor who created this label."
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "AT URI of the record, repository (account), or other resource that this label applies to."
+        },
+        "val": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "The short string name of the value or type of this label."
+        },
+        "ver": {
+          "type": "integer",
+          "description": "The AT Protocol version of the label object."
+        }
+      },
+      "description": "Metadata tag on an atproto resource (eg, repo or record)."
+    },
+    "selfLabel": {
+      "type": "object",
+      "required": [
+        "val"
+      ],
+      "properties": {
+        "val": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "The short string name of the value or type of this label."
+        }
+      },
+      "description": "Metadata tag on an atproto record, published by the author within the record. Note that schemas should use #selfLabels, not #selfLabel."
+    },
+    "labelValue": {
+      "type": "string",
+      "knownValues": [
+        "!hide",
+        "!warn",
+        "!no-unauthenticated",
+        "porn",
+        "sexual",
+        "nudity",
+        "graphic-media",
+        "bot"
+      ]
+    },
+    "selfLabels": {
+      "type": "object",
+      "required": [
+        "values"
+      ],
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "ref": "#selfLabel",
+            "type": "ref"
+          },
+          "maxLength": 10
+        }
+      },
+      "description": "Metadata tags on an atproto record, published by the author within the record."
+    },
+    "labelValueDefinition": {
+      "type": "object",
+      "required": [
+        "identifier",
+        "severity",
+        "blurs",
+        "locales"
+      ],
+      "properties": {
+        "blurs": {
+          "type": "string",
+          "description": "What should this label hide in the UI, if applied? 'content' hides all of the target; 'media' hides the images/video/audio; 'none' hides nothing.",
+          "knownValues": [
+            "content",
+            "media",
+            "none"
+          ]
+        },
+        "locales": {
+          "type": "array",
+          "items": {
+            "ref": "#labelValueDefinitionStrings",
+            "type": "ref"
+          }
+        },
+        "severity": {
+          "type": "string",
+          "description": "How should a client visually convey this label? 'inform' means neutral and informational; 'alert' means negative and warning; 'none' means show nothing.",
+          "knownValues": [
+            "inform",
+            "alert",
+            "none"
+          ]
+        },
+        "adultOnly": {
+          "type": "boolean",
+          "description": "Does the user need to have adult content enabled in order to configure this label?"
+        },
+        "identifier": {
+          "type": "string",
+          "maxLength": 100,
+          "description": "The value of the label being defined. Must only include lowercase ascii and the '-' character ([a-z-]+).",
+          "maxGraphemes": 100
+        },
+        "defaultSetting": {
+          "type": "string",
+          "default": "warn",
+          "description": "The default setting for this label.",
+          "knownValues": [
+            "ignore",
+            "warn",
+            "hide"
+          ]
+        }
+      },
+      "description": "Declares a label value and its expected interpretations and behaviors."
+    },
+    "labelValueDefinitionStrings": {
+      "type": "object",
+      "required": [
+        "lang",
+        "name",
+        "description"
+      ],
+      "properties": {
+        "lang": {
+          "type": "string",
+          "format": "language",
+          "description": "The code of the language these strings are written in."
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 640,
+          "description": "A short human-readable name for the label.",
+          "maxGraphemes": 64
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 100000,
+          "description": "A longer description of what the label means and why it might be applied.",
+          "maxGraphemes": 10000
+        }
+      },
+      "description": "Strings which describe the label in the UI, localized into a specific language."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/com/atproto/moderation/defs.json
+++ b/lexicons/com/atproto/moderation/defs.json
@@ -1,0 +1,96 @@
+{
+  "id": "com.atproto.moderation.defs",
+  "defs": {
+    "reasonRude": {
+      "type": "token",
+      "description": "Rude, harassing, explicit, or otherwise unwelcoming behavior. Prefer new lexicon definition `tools.ozone.report.defs#reasonHarassmentOther`."
+    },
+    "reasonSpam": {
+      "type": "token",
+      "description": "Spam: frequent unwanted promotion, replies, mentions. Prefer new lexicon definition `tools.ozone.report.defs#reasonMisleadingSpam`."
+    },
+    "reasonType": {
+      "type": "string",
+      "knownValues": [
+        "com.atproto.moderation.defs#reasonSpam",
+        "com.atproto.moderation.defs#reasonViolation",
+        "com.atproto.moderation.defs#reasonMisleading",
+        "com.atproto.moderation.defs#reasonSexual",
+        "com.atproto.moderation.defs#reasonRude",
+        "com.atproto.moderation.defs#reasonOther",
+        "com.atproto.moderation.defs#reasonAppeal",
+        "tools.ozone.report.defs#reasonAppeal",
+        "tools.ozone.report.defs#reasonOther",
+        "tools.ozone.report.defs#reasonViolenceAnimal",
+        "tools.ozone.report.defs#reasonViolenceThreats",
+        "tools.ozone.report.defs#reasonViolenceGraphicContent",
+        "tools.ozone.report.defs#reasonViolenceGlorification",
+        "tools.ozone.report.defs#reasonViolenceExtremistContent",
+        "tools.ozone.report.defs#reasonViolenceTrafficking",
+        "tools.ozone.report.defs#reasonViolenceOther",
+        "tools.ozone.report.defs#reasonSexualAbuseContent",
+        "tools.ozone.report.defs#reasonSexualNCII",
+        "tools.ozone.report.defs#reasonSexualDeepfake",
+        "tools.ozone.report.defs#reasonSexualAnimal",
+        "tools.ozone.report.defs#reasonSexualUnlabeled",
+        "tools.ozone.report.defs#reasonSexualOther",
+        "tools.ozone.report.defs#reasonChildSafetyCSAM",
+        "tools.ozone.report.defs#reasonChildSafetyGroom",
+        "tools.ozone.report.defs#reasonChildSafetyPrivacy",
+        "tools.ozone.report.defs#reasonChildSafetyHarassment",
+        "tools.ozone.report.defs#reasonChildSafetyOther",
+        "tools.ozone.report.defs#reasonHarassmentTroll",
+        "tools.ozone.report.defs#reasonHarassmentTargeted",
+        "tools.ozone.report.defs#reasonHarassmentHateSpeech",
+        "tools.ozone.report.defs#reasonHarassmentDoxxing",
+        "tools.ozone.report.defs#reasonHarassmentOther",
+        "tools.ozone.report.defs#reasonMisleadingBot",
+        "tools.ozone.report.defs#reasonMisleadingImpersonation",
+        "tools.ozone.report.defs#reasonMisleadingSpam",
+        "tools.ozone.report.defs#reasonMisleadingScam",
+        "tools.ozone.report.defs#reasonMisleadingElections",
+        "tools.ozone.report.defs#reasonMisleadingOther",
+        "tools.ozone.report.defs#reasonRuleSiteSecurity",
+        "tools.ozone.report.defs#reasonRuleProhibitedSales",
+        "tools.ozone.report.defs#reasonRuleBanEvasion",
+        "tools.ozone.report.defs#reasonRuleOther",
+        "tools.ozone.report.defs#reasonSelfHarmContent",
+        "tools.ozone.report.defs#reasonSelfHarmED",
+        "tools.ozone.report.defs#reasonSelfHarmStunts",
+        "tools.ozone.report.defs#reasonSelfHarmSubstances",
+        "tools.ozone.report.defs#reasonSelfHarmOther"
+      ]
+    },
+    "reasonOther": {
+      "type": "token",
+      "description": "Reports not falling under another report category. Prefer new lexicon definition `tools.ozone.report.defs#reasonOther`."
+    },
+    "subjectType": {
+      "type": "string",
+      "description": "Tag describing a type of subject that might be reported.",
+      "knownValues": [
+        "account",
+        "record",
+        "chat"
+      ]
+    },
+    "reasonAppeal": {
+      "type": "token",
+      "description": "Appeal a previously taken moderation action"
+    },
+    "reasonSexual": {
+      "type": "token",
+      "description": "Unwanted or mislabeled sexual content. Prefer new lexicon definition `tools.ozone.report.defs#reasonSexualUnlabeled`."
+    },
+    "reasonViolation": {
+      "type": "token",
+      "description": "Direct violation of server rules, laws, terms of service. Prefer new lexicon definition `tools.ozone.report.defs#reasonRuleOther`."
+    },
+    "reasonMisleading": {
+      "type": "token",
+      "description": "Misleading identity, affiliation, or content. Prefer new lexicon definition `tools.ozone.report.defs#reasonMisleadingOther`."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/com/atproto/repo/strongRef.json
+++ b/lexicons/com/atproto/repo/strongRef.json
@@ -1,0 +1,25 @@
+{
+  "id": "com.atproto.repo.strongRef",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": [
+        "uri",
+        "cid"
+      ],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
+  "description": "A URI with a content-hash fingerprint."
+}

--- a/lexicons/tools/ozone/report/defs.json
+++ b/lexicons/tools/ozone/report/defs.json
@@ -1,0 +1,212 @@
+{
+  "id": "tools.ozone.report.defs",
+  "defs": {
+    "reasonType": {
+      "type": "string",
+      "knownValues": [
+        "tools.ozone.report.defs#reasonAppeal",
+        "tools.ozone.report.defs#reasonOther",
+        "tools.ozone.report.defs#reasonViolenceAnimal",
+        "tools.ozone.report.defs#reasonViolenceThreats",
+        "tools.ozone.report.defs#reasonViolenceGraphicContent",
+        "tools.ozone.report.defs#reasonViolenceGlorification",
+        "tools.ozone.report.defs#reasonViolenceExtremistContent",
+        "tools.ozone.report.defs#reasonViolenceTrafficking",
+        "tools.ozone.report.defs#reasonViolenceOther",
+        "tools.ozone.report.defs#reasonSexualAbuseContent",
+        "tools.ozone.report.defs#reasonSexualNCII",
+        "tools.ozone.report.defs#reasonSexualDeepfake",
+        "tools.ozone.report.defs#reasonSexualAnimal",
+        "tools.ozone.report.defs#reasonSexualUnlabeled",
+        "tools.ozone.report.defs#reasonSexualOther",
+        "tools.ozone.report.defs#reasonChildSafetyCSAM",
+        "tools.ozone.report.defs#reasonChildSafetyGroom",
+        "tools.ozone.report.defs#reasonChildSafetyPrivacy",
+        "tools.ozone.report.defs#reasonChildSafetyHarassment",
+        "tools.ozone.report.defs#reasonChildSafetyOther",
+        "tools.ozone.report.defs#reasonHarassmentTroll",
+        "tools.ozone.report.defs#reasonHarassmentTargeted",
+        "tools.ozone.report.defs#reasonHarassmentHateSpeech",
+        "tools.ozone.report.defs#reasonHarassmentDoxxing",
+        "tools.ozone.report.defs#reasonHarassmentOther",
+        "tools.ozone.report.defs#reasonMisleadingBot",
+        "tools.ozone.report.defs#reasonMisleadingImpersonation",
+        "tools.ozone.report.defs#reasonMisleadingSpam",
+        "tools.ozone.report.defs#reasonMisleadingScam",
+        "tools.ozone.report.defs#reasonMisleadingElections",
+        "tools.ozone.report.defs#reasonMisleadingOther",
+        "tools.ozone.report.defs#reasonRuleSiteSecurity",
+        "tools.ozone.report.defs#reasonRuleProhibitedSales",
+        "tools.ozone.report.defs#reasonRuleBanEvasion",
+        "tools.ozone.report.defs#reasonRuleOther",
+        "tools.ozone.report.defs#reasonSelfHarmContent",
+        "tools.ozone.report.defs#reasonSelfHarmED",
+        "tools.ozone.report.defs#reasonSelfHarmStunts",
+        "tools.ozone.report.defs#reasonSelfHarmSubstances",
+        "tools.ozone.report.defs#reasonSelfHarmOther"
+      ]
+    },
+    "reasonOther": {
+      "type": "token",
+      "description": "An issue not included in these options"
+    },
+    "reasonAppeal": {
+      "type": "token",
+      "description": "Appeal a previously taken moderation action"
+    },
+    "reasonRuleOther": {
+      "type": "token",
+      "description": "Other"
+    },
+    "reasonSelfHarmED": {
+      "type": "token",
+      "description": "Eating disorders"
+    },
+    "reasonSexualNCII": {
+      "type": "token",
+      "description": "Non-consensual intimate imagery"
+    },
+    "reasonSexualOther": {
+      "type": "token",
+      "description": "Other sexual violence content"
+    },
+    "reasonSexualAnimal": {
+      "type": "token",
+      "description": "Animal sexual abuse"
+    },
+    "reasonMisleadingBot": {
+      "type": "token",
+      "description": "Fake account or bot"
+    },
+    "reasonSelfHarmOther": {
+      "type": "token",
+      "description": "Other dangerous content"
+    },
+    "reasonViolenceOther": {
+      "type": "token",
+      "description": "Other violent content"
+    },
+    "reasonMisleadingScam": {
+      "type": "token",
+      "description": "Scam"
+    },
+    "reasonMisleadingSpam": {
+      "type": "token",
+      "description": "Spam"
+    },
+    "reasonRuleBanEvasion": {
+      "type": "token",
+      "description": "Banned user returning"
+    },
+    "reasonSelfHarmStunts": {
+      "type": "token",
+      "description": "Dangerous challenges or activities"
+    },
+    "reasonSexualDeepfake": {
+      "type": "token",
+      "description": "Deepfake adult content"
+    },
+    "reasonViolenceAnimal": {
+      "type": "token",
+      "description": "Animal welfare violations"
+    },
+    "reasonChildSafetyCSAM": {
+      "type": "token",
+      "description": "Child sexual abuse material (CSAM). These reports will be sent only be sent to the application's Moderation Authority."
+    },
+    "reasonHarassmentOther": {
+      "type": "token",
+      "description": "Other harassing or hateful content"
+    },
+    "reasonHarassmentTroll": {
+      "type": "token",
+      "description": "Trolling"
+    },
+    "reasonMisleadingOther": {
+      "type": "token",
+      "description": "Other misleading content"
+    },
+    "reasonSelfHarmContent": {
+      "type": "token",
+      "description": "Content promoting or depicting self-harm"
+    },
+    "reasonSexualUnlabeled": {
+      "type": "token",
+      "description": "Unlabelled adult content"
+    },
+    "reasonViolenceThreats": {
+      "type": "token",
+      "description": "Threats or incitement"
+    },
+    "reasonChildSafetyGroom": {
+      "type": "token",
+      "description": "Grooming or predatory behavior. These reports will be sent only be sent to the application's Moderation Authority."
+    },
+    "reasonChildSafetyOther": {
+      "type": "token",
+      "description": "Other child safety. These reports will be sent only be sent to the application's Moderation Authority."
+    },
+    "reasonRuleSiteSecurity": {
+      "type": "token",
+      "description": "Hacking or system attacks"
+    },
+    "reasonHarassmentDoxxing": {
+      "type": "token",
+      "description": "Doxxing"
+    },
+    "reasonChildSafetyPrivacy": {
+      "type": "token",
+      "description": "Privacy violation involving a minor"
+    },
+    "reasonHarassmentTargeted": {
+      "type": "token",
+      "description": "Targeted harassment"
+    },
+    "reasonSelfHarmSubstances": {
+      "type": "token",
+      "description": "Dangerous substances or drug abuse"
+    },
+    "reasonSexualAbuseContent": {
+      "type": "token",
+      "description": "Adult sexual abuse content"
+    },
+    "reasonMisleadingElections": {
+      "type": "token",
+      "description": "False information about elections"
+    },
+    "reasonRuleProhibitedSales": {
+      "type": "token",
+      "description": "Promoting or selling prohibited items or services"
+    },
+    "reasonViolenceTrafficking": {
+      "type": "token",
+      "description": "Human trafficking"
+    },
+    "reasonHarassmentHateSpeech": {
+      "type": "token",
+      "description": "Hate speech"
+    },
+    "reasonChildSafetyHarassment": {
+      "type": "token",
+      "description": "Harassment or bullying of minors"
+    },
+    "reasonViolenceGlorification": {
+      "type": "token",
+      "description": "Glorification of violence"
+    },
+    "reasonViolenceGraphicContent": {
+      "type": "token",
+      "description": "Graphic violent content"
+    },
+    "reasonMisleadingImpersonation": {
+      "type": "token",
+      "description": "Impersonation"
+    },
+    "reasonViolenceExtremistContent": {
+      "type": "token",
+      "description": "Extremist content. These reports will be sent only be sent to the application's Moderation Authority."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
-    "@atproto/api": "0.20.42",
     "@atproto/did": "0.5.4",
     "@atproto/identity": "0.5.10",
     "@atproto/jwk-jose": "0.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@atproto/api':
-        specifier: 0.20.42
-        version: 0.20.42
       '@atproto/did':
         specifier: 0.5.4
         version: 0.5.4
@@ -315,10 +312,6 @@ packages:
 
   '@atproto-labs/simple-store@0.5.1':
     resolution: {integrity: sha512-vfvoDhu6ds6BT3Pqe+d2/LBU1WpDRtt69y6zltlfMCoucPm82m1j50/Wb6xTvv+oZ+2j0JyZVXsmXQ12SWYQJg==}
-    engines: {node: '>=22'}
-
-  '@atproto/api@0.20.42':
-    resolution: {integrity: sha512-x86WgkHFcNqDIo8gf52npc1KvFXlIPDLAJdIhiH1uUAwiQxDw8/WU0iH3pTl1OXMKkB93kwxG0ihx0fTi5FPbw==}
     engines: {node: '>=22'}
 
   '@atproto/common-web@0.5.10':
@@ -1486,9 +1479,6 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
-
-  await-lock@3.0.0:
-    resolution: {integrity: sha512-eO6fLiSnrJrMdjWMNK8zbVRXPs2TKJg78iKZd9wDpN3na5tcoV6EoeiOlMgk2QaAQ1gIrK1YuMsJHXWqz89tSA==}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -3273,10 +3263,6 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tlds@1.261.0:
-    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
-    hasBin: true
-
   tldts-core@7.4.2:
     resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
 
@@ -3703,17 +3689,6 @@ snapshots:
       lru-cache: 10.4.3
 
   '@atproto-labs/simple-store@0.5.1': {}
-
-  '@atproto/api@0.20.42':
-    dependencies:
-      '@atproto/common-web': 0.5.10
-      '@atproto/lexicon': 0.7.12
-      '@atproto/syntax': 0.7.5
-      '@atproto/xrpc': 0.8.11
-      await-lock: 3.0.0
-      multiformats: 13.4.2
-      tlds: 1.261.0
-      zod: 3.25.76
 
   '@atproto/common-web@0.5.10':
     dependencies:
@@ -4955,8 +4930,6 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
-
-  await-lock@3.0.0: {}
 
   babel-dead-code-elimination@1.0.12(supports-color@7.2.0):
     dependencies:
@@ -6751,8 +6724,6 @@ snapshots:
       picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
-
-  tlds@1.261.0: {}
 
   tldts-core@7.4.2: {}
 


### PR DESCRIPTION
## 概要

`@atproto/lex-cli` から `@atproto/lex` への移行(#335)に伴い、`LinkatAgent` を `@atproto/api` の `Agent` から `@atproto/lex` の `Client` に移行し、`@atproto/api` への依存を削除しました。

## 動作確認

- `pnpm typecheck` / `pnpm lint` / `pnpm build`: 通過
- CI(unit-test / e2e-test): 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLZG9ZnrQBEnixB5YzQuUQ