### PR TITLE
Remove aws-cli pin workaround for resolved Cloudflare R2 incident

### DIFF
--- a/.github/workflows/e2e-production.yml
+++ b/.github/workflows/e2e-production.yml
@@ -55,11 +55,6 @@ jobs:
           PLAYWRIGHT_TEST_BASE_URL: https://linkat.blue
           E2E_HANDLE: ${{ secrets.E2E_HANDLE }}
           E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
-      # https://www.cloudflarestatus.com/incidents/t5nrjmpxc1cj
-      - uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # 1.0.8
-        if: always()
-        with:
-          version: 2.22.35
       - name: Upload Report
         if: always()
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,11 +47,6 @@ jobs:
         env:
           E2E_HANDLE: ${{ secrets.E2E_HANDLE }}
           E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
-      # https://www.cloudflarestatus.com/incidents/t5nrjmpxc1cj
-      - uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # 1.0.8
-        if: always() && (github.ref == 'refs/heads/main' || github.actor == 'mkizka')
-        with:
-          version: 2.22.35
       - name: Upload Report
         if: always() && (github.ref == 'refs/heads/main' || github.actor == 'mkizka')
         run: |


### PR DESCRIPTION
## 概要

E2Eレポートのアップロード前に特定バージョンのAWS CLIを明示的にインストールしていた回避策を削除しました。

## 背景

このステップは、2025年1月17日〜2月3日に発生したCloudflare R2側のインシデント（[t5nrjmpxc1cj](https://www.cloudflarestatus.com/incidents/t5nrjmpxc1cj)）への対処として追加されたものです。AWS SDKがCRC32チェックサムをデフォルト有効化した際、R2側が未対応で `aws s3 cp` が失敗していました。

このインシデントは既に解決済みで、`ubuntu-latest` ランナー標準搭載のAWS CLIで問題なく動作するため、`test.yml` と `e2e-production.yml` の両方から該当ステップを削除しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)