### PR TITLE
Notify Discord with e2e-production result

### DIFF
--- a/.github/workflows/e2e-production.yml
+++ b/.github/workflows/e2e-production.yml
@@ -65,8 +65,25 @@ jobs:
         run: |
           E2E_S3_PATH="playwright-report/production"
           aws s3 cp playwright-report "s3://$E2E_S3_PATH" --recursive
+          echo "E2E_REPORT_URL=${{ vars.S3_BASE_URL }}/$E2E_S3_PATH/index.html" >> $GITHUB_ENV
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
           AWS_DEFAULT_REGION: auto
+      - name: Notify Discord
+        if: always()
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            MESSAGE="✅ E2E Test (Production) succeeded"
+          else
+            MESSAGE="❌ E2E Test (Production) failed"
+          fi
+          jq -n \
+            --arg message "$MESSAGE" \
+            --arg report "$E2E_REPORT_URL" \
+            --arg run "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{content: "\($message)\n📊 \($report)\n🔗 \($run)"}' |
+            curl -sf -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## 概要

`e2e-production` ワークフローの完了時に、成功・失敗どちらの場合もDiscordへ通知を送るようにしました。

## 変更内容

- レポートアップロード後にレポートURLを `E2E_REPORT_URL` として環境変数に保存
- `job.status` を見て成功/失敗のメッセージを組み立て、レポートURLと実行URLを添えてDiscord Webhookにポスト

## 必要な設定

`DISCORD_WEBHOOK_URL` をリポジトリのSecretsに登録してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tJq9o1vjKVw24FknaXcCk