### PR TITLE
Add commit URL and blank line to Discord e2e-production notification

### DIFF
--- a/.github/workflows/e2e-production.yml
+++ b/.github/workflows/e2e-production.yml
@@ -78,7 +78,8 @@ jobs:
             --arg message "$MESSAGE" \
             --arg report "$E2E_REPORT_URL" \
             --arg run "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            '{content: "\($message)\n📊 \($report)\n🔗 \($run)"}' |
+            --arg commit "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }}" \
+            '{content: "\($message)\n\n📊 \($report)\n🔗 \($run)\n📝 \($commit)"}' |
             curl -sf -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## 概要

e2e-productionのDiscord通知メッセージのフォーマットを変更しました。

- メッセージ本文とURL群の間に空行を追加
- トリガーとなったコミットのURLを追加

## 変更後のフォーマット

```
✅/❌ メッセージ

📊 PlaywrightレポートURL
🔗 GitHub ActionsのURL
📝 コミットURL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb2ohc1X3mEbRfmq7VJ4Hq