### PR TITLE
Queue pending e2e runs instead of dropping them

### DIFF
--- a/.github/workflows/e2e-production.yml
+++ b/.github/workflows/e2e-production.yml
@@ -13,6 +13,7 @@ jobs:
     concurrency:
       group: e2e-test-production
       cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
     concurrency:
       group: e2e-test
       cancel-in-progress: false
+      queue: max
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## 概要

`e2e-test` / `e2e-test-production` の concurrency group は固定のグループ名を使って同一Blueskyアカウントへの直列アクセスを担保していますが、GitHub Actionsのデフォルト挙動は「実行中1つ + 待機中1つ」までしか保持できず、3件目以降のトリガーが来ると待機中の古いジョブが `cancelled` になっていました。

さらにこの`e2e-test`のキャンセルが「Test」ワークフロー全体の conclusion を非successにし、`workflow_run` で連動する `e2e-production` が `skipped` になる連鎖も発生していました。

## 変更内容

両ジョブの concurrency 設定に `queue: max` を追加し、待機ジョブをキャンセルせず順番に処理するようにしました(2026年5月にリリースされたGitHub Actionsの機能、最大100件まで待機可能)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3se36jp9kmPgftJcSKEDg