### PR TITLE
Verify lexicon integrity via lex install --ci in postinstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm i -g corepack@latest && \
     corepack enable pnpm
 
 FROM base AS build
-COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml lexicons.json ./
 COPY --link scripts ./scripts
 COPY --link prisma ./prisma
 COPY --link lexicons ./lexicons

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start:local": "NODE_ENV=development E2E=1 DISABLE_JETSTREAM=true node --env-file .env ./dist/server.js",
     "test": "vitest run",
     "typecheck": "react-router typegen && tsc",
-    "update-lexicons": "lex install --update --lexicons ./lexicons"
+    "update-lexicons": "lex install --update"
   },
   "dependencies": {
     "@atproto/did": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "NODE_ENV=production node ./dist/server.js",
     "start:local": "NODE_ENV=development E2E=1 DISABLE_JETSTREAM=true node --env-file .env ./dist/server.js",
     "test": "vitest run",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc",
+    "update-lexicons": "lex install --update --lexicons ./lexicons"
   },
   "dependencies": {
     "@atproto/did": "0.5.4",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+pnpm lex install --ci --lexicons ./lexicons
 pnpm lex build --lexicons ./lexicons --out ./app/generated --clear
 
 pnpm prisma generate

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-pnpm lex install --ci --lexicons ./lexicons
-pnpm lex build --lexicons ./lexicons --out ./app/generated --clear
+pnpm lex install --ci
+pnpm lex build --out ./app/generated --clear
 
 pnpm prisma generate

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -3,5 +3,4 @@ set -euo pipefail
 
 pnpm lex install --ci
 pnpm lex build --out ./app/generated --clear
-
 pnpm prisma generate


### PR DESCRIPTION
## 概要

`@atproto/lex` の [Workflow Integration](https://github.com/bluesky-social/atproto/tree/main/packages/lex/lex#workflow-integration) の推奨に沿って、`postinstall` に `lex install --ci` を追加しました。これにより `lexicons/` 配下のファイルが `lexicons.json` に記録された CID と一致するかを依存関係インストール後に検証できます。

また、レキシコンを手動で最新化するための `update-lexicons` (`lex install --update`) スクリプトを追加しました。

`prebuild` での生成分離も検討しましたが、CI の unit-test ジョブや `pnpm dev` が `pnpm build` を経由しないため、生成物は `postinstall` の時点で揃えておく必要があり、既存の構成を踏襲しています。

## その他

`--lexicons` `--manifest` オプションは `lex` のデフォルト値と同じだったため、コマンドから削除しました。