### PR TITLE
Remove leftover local-PDS-only OAuth client options

### DIFF
--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -7,7 +7,6 @@ import { RouteToaster } from "~/features/toast/route";
 import { getInstance } from "~/i18n/i18n";
 import { oauthClient } from "~/server/oauth/client";
 import { getSessionUserDid } from "~/server/oauth/session";
-import { isProduction } from "~/utils/env";
 import { createLogger } from "~/utils/logger";
 
 import type { Route } from "./+types/login";
@@ -22,9 +21,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     return { error: i18next.t("login.unknown-error") };
   }
   try {
-    const scope = isProduction
-      ? "atproto include:blue.linkat.permissionSet"
-      : "atproto transition:generic";
+    const scope = "atproto include:blue.linkat.permissionSet";
     const url = await oauthClient.authorize(handle, { scope });
     return redirect(url.toString());
   } catch (error) {

--- a/app/server/oauth/client.ts
+++ b/app/server/oauth/client.ts
@@ -14,9 +14,7 @@ import { SessionStore, StateStore } from "./storage";
 
 const privateKey = Buffer.from(env.PRIVATE_KEY_ES256_B64, "base64").toString();
 
-const scope = isProduction
-  ? "atproto include:blue.linkat.permissionSet"
-  : "atproto transition:generic";
+const scope = "atproto include:blue.linkat.permissionSet";
 
 const clientMetadata: OAuthClientMetadataInput = isProduction
   ? {

--- a/app/server/oauth/client.ts
+++ b/app/server/oauth/client.ts
@@ -52,8 +52,4 @@ const oauthClientOptions: NodeOAuthClientOptions = {
   sessionStore: new SessionStore(),
 };
 
-if (!isProduction) {
-  oauthClientOptions.handleResolver = env.BSKY_PUBLIC_API_URL;
-}
-
 export const oauthClient = new NodeOAuthClient(oauthClientOptions);

--- a/app/server/oauth/client.ts
+++ b/app/server/oauth/client.ts
@@ -54,7 +54,6 @@ const oauthClientOptions: NodeOAuthClientOptions = {
 
 if (!isProduction) {
   oauthClientOptions.handleResolver = env.BSKY_PUBLIC_API_URL;
-  oauthClientOptions.allowHttp = true; // httpを許可しないとOAuthProtectedResourceMetadataResolverがエラーを投げる
 }
 
 export const oauthClient = new NodeOAuthClient(oauthClientOptions);


### PR DESCRIPTION
## Summary
- ローカルPDS(http)をやめて実PDS(https)を使うようになった(#334)結果、`app/server/oauth/client.ts`にローカルPDS時代の名残が残っていたので削除
  - `allowHttp: true`: `OAuthProtectedResourceMetadataResolver`/`OAuthAuthorizationServerMetadataResolver`がPDSのメタデータをhttpで取得できるようにする設定。実PDS(https)のみを使う今は不要
  - dev用の`handleResolver`オーバーライド: ローカルdev-envの疑似ハンドルを解決するためのものだったが、実際のBlueskyハンドル(DNS解決可能)を使う今は不要で、本番と同じデフォルトのDNSベース解決で問題ない
  - dev/prodで分かれていた`scope`(`atproto transition:generic` vs `atproto include:blue.linkat.permissionSet`)も統一。loopbackクライアントがpermission setスコープを使えない、という制約は仕様上見当たらず、CIのe2eテスト(実アカウントでのOAuthログイン)で実際に動作することを確認できたため

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] CIのe2eテストが実PDSに対するOAuthログイン(`include:blue.linkat.permissionSet`スコープ含む)で成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KYw8uekoD1J1wi224GGCU

---
_Generated by [Claude Code](https://claude.ai/code/session_018KYw8uekoD1J1wi224GGCU)_