### PR TITLE
Add GitHub Actions workflow for Railway IaC plan/apply

### DIFF
--- a/.github/workflows/railway-config.yml
+++ b/.github/workflows/railway-config.yml
@@ -1,0 +1,35 @@
+name: Railway config
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - ".railway/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  plan:
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: railwayapp/config@9e17d413dbe219f19d62538d9c06b5dbb5e9abf8 # v1.2.0
+        with:
+          command: plan
+          railway-token: ${{ secrets.RAILWAY_TOKEN }}
+
+  apply:
+    if: github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - uses: railwayapp/config@9e17d413dbe219f19d62538d9c06b5dbb5e9abf8 # v1.2.0
+        with:
+          command: apply
+          railway-token: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
## 概要

前回のコミットで `.railway/railway.ts` によるRailway Infrastructure as Codeへ移行したため、CIに組み込みます。

## 内容

- `.railway/**` の変更を含むPRで `railway config plan` を実行し、差分をPRコメントで確認できるようにする
- mainへのマージ時に、そのPRでレビューされたplanをそのまま `railway config apply` する（公式アクション [railwayapp/config](https://github.com/railwayapp/config) を使用）
- forkからのPRはRailwayトークンにアクセスできないため対象外

## 注意事項

- 事前に `RAILWAY_TOKEN`（対象環境のプロジェクトトークン）をリポジトリシークレットに登録する必要があります
- `.railway/railway.ts` の環境変数やビルド設定を変更してマージすると、GitHub連携の自動デプロイとは別に、apply自体が新しいデプロイをトリガーする可能性があります

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HzkoVH8F7SJcewAdjU9SB